### PR TITLE
Publish large comment as gist

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.0.11
+:Version: 2.0.12
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/terraform/tests/github_pr/test_publish_gist.py
+++ b/infrahouse_toolkit/terraform/tests/github_pr/test_publish_gist.py
@@ -1,0 +1,12 @@
+from os import environ
+
+import pytest
+from github import Github, InputFileContent
+
+
+@pytest.mark.skipif("GITHUB_TOKEN" not in environ, reason="This is a development test, needs GITHUB_TOKEN")
+def test_publish_gist():
+    gh = Github(login_or_token=environ["GITHUB_TOKEN"])
+    user = gh.get_user()
+    gist = user.create_gist(public=False, files={"test": InputFileContent("foo", "new_name")})
+    print(gist.html_url)

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.0.11'
+build_version '2.0.12'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.11
+current_version = 2.0.12
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.0.11",
+    version="2.0.12",
     zip_safe=False,
 )


### PR DESCRIPTION
- Publish plan as a gist of it's too large
- Bump version: 2.0.11 → 2.0.12
