### PR TITLE
fix gist name

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.0.12
+:Version: 2.0.13
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.0.12"
+__version__ = "2.0.13"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/terraform/githubpr.py
+++ b/infrahouse_toolkit/terraform/githubpr.py
@@ -108,7 +108,8 @@ class GitHubPR:
                     public=True,
                     files={
                         f"pr-{self._pr_number}-plan": InputFileContent(
-                            content=comment, new_name=f"{self._repo_name}-pr-{self._pr_number}-plan.txt"
+                            content=comment,
+                            new_name=f"{self._repo_name.replace('/','-')}-pr-{self._pr_number}-plan.txt",
                         )
                     },
                 )

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.0.12'
+build_version '2.0.13'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.12
+current_version = 2.0.13
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.0.12",
+    version="2.0.13",
     zip_safe=False,
 )


### PR DESCRIPTION
- File name cannot include slash
- Bump version: 2.0.12 → 2.0.13
