### PR TITLE
min permissions with new provides

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.3.1
+:Version: 2.4.0
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.3.1"
+__version__ = "2.4.0"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
@@ -120,9 +120,11 @@ class ActionList:
             for line in f_decs.readlines():
                 try:
                     operation = json.loads(line)
-                    if "aws.operation" in operation:
-                        service_name = operation["aws.service"].lower()
-                        permission = self._normalize_action(f'{service_name}:{operation["aws.operation"]}')
+                    operation_key = "aws.operation" if "aws.operation" in operation else "rpc.method"
+                    service_key = "aws.service" if "aws.service" in operation else "rpc.service"
+                    if all((operation_key in operation, service_key in operation)):
+                        service_name = operation[service_key].lower()
+                        permission = self._normalize_action(f"{service_name}:{operation[operation_key]}")
                         if permission not in existing_permissions:
                             self.add(permission)
 

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_parse_trace.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_parse_trace.py
@@ -1,5 +1,7 @@
 from textwrap import dedent
 
+import pytest
+
 from infrahouse_toolkit.cli.ih_plan.cmd_min_permissions import ActionList
 
 
@@ -21,29 +23,45 @@ def test_parse_trace(tmpdir):
     ]
 
 
-def test_parse_trace_permissions_map(tmpdir):
+@pytest.mark.parametrize(
+    "trace_content, expected_permissions",
+    [
+        (
+            dedent(
+                """
+                {"aws.operation": "HeadBucket","aws.service": "S3"}
+                {"aws.operation": "GetBucketAccelerateConfiguration","aws.service": "S3"}
+                {"aws.operation": "GetBucketEncryption","aws.service": "S3"}
+                {"aws.operation": "GetBucketCors","aws.service": "S3"}
+                {"aws.operation": "GetBucketLifecycleConfiguration","aws.service": "S3"}
+                {"aws.operation": "GetBucketReplication","aws.service": "S3"}
+                {"aws.operation": "GetObjectLockConfiguration","aws.service": "S3"}
+                """
+            ),
+            [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetBucketCORS",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket",
+            ],
+        ),
+        (
+            dedent(
+                """
+                {"rpc.method": "CreateBucket", "rpc.service": "S3"}
+                {"rpc.method": "CreateTable", "rpc.service": "DynamoDB"}
+                """
+            ),
+            ["s3:CreateBucket", "dynamodb:CreateTable"],
+        ),
+    ],
+)
+def test_parse_trace_permissions_map(tmpdir, trace_content, expected_permissions):
     tracefile = tmpdir.join("trace")
-    tracefile.write(
-        dedent(
-            """
-            {"aws.operation": "HeadBucket","aws.service": "S3"}
-            {"aws.operation": "GetBucketAccelerateConfiguration","aws.service": "S3"}
-            {"aws.operation": "GetBucketEncryption","aws.service": "S3"}
-            {"aws.operation": "GetBucketCors","aws.service": "S3"}
-            {"aws.operation": "GetBucketLifecycleConfiguration","aws.service": "S3"}
-            {"aws.operation": "GetBucketReplication","aws.service": "S3"}
-            {"aws.operation": "GetObjectLockConfiguration","aws.service": "S3"}
-            """
-        )
-    )
+    tracefile.write(trace_content)
     actions = ActionList()
     actions.parse_trace(str(tracefile))
-    assert actions.actions == [
-        "s3:GetAccelerateConfiguration",
-        "s3:GetBucketCORS",
-        "s3:GetBucketObjectLockConfiguration",
-        "s3:GetEncryptionConfiguration",
-        "s3:GetLifecycleConfiguration",
-        "s3:GetReplicationConfiguration",
-        "s3:ListBucket",
-    ]
+    assert sorted(actions.actions) == sorted(expected_permissions)

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.3.1'
+build_version '2.4.0'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.1
+current_version = 2.4.0
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.3.1",
+    version="2.4.0",
     zip_safe=False,
 )


### PR DESCRIPTION
- ih-plan min-permissions supports aws provider > 5.11
- Bump version: 2.3.1 → 2.4.0
