### PR TITLE
Generate permissions needed by special AWS API calls

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.4.0
+:Version: 2.4.1
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
@@ -75,6 +75,9 @@ class ActionList:
         "GetBucketLifecycleConfiguration": "GetLifecycleConfiguration",
         "GetBucketReplication": "GetReplicationConfiguration",
         "GetObjectLockConfiguration": "GetBucketObjectLockConfiguration",
+        "DeletePublicAccessBlock": "PutBucketPublicAccessBlock",
+        "GetPublicAccessBlock": "GetBucketPublicAccessBlock",
+        "PutPublicAccessBlock": "PutBucketPublicAccessBlock",
     }
     # Some permissions require additional ones.
     REQUIRED_EXTRA_PERMISSIONS_MAP = {
@@ -127,6 +130,25 @@ class ActionList:
                         permission = self._normalize_action(f"{service_name}:{operation[operation_key]}")
                         if permission not in existing_permissions:
                             self.add(permission)
+                    elif all(
+                        (
+                            operation.get("tf_resource_type") == "aws_s3_bucket_versioning",
+                            operation.get("tf_rpc") == "ApplyResourceChange",
+                        )
+                    ):
+                        permission = "s3:PutBucketVersioning"
+                    elif all(
+                        (
+                            operation.get("tf_resource_type") == "aws_s3_bucket_server_side_encryption_configuration",
+                            operation.get("tf_rpc") == "ApplyResourceChange",
+                        )
+                    ):
+                        permission = "s3:PutEncryptionConfiguration"
+                    else:
+                        continue
+
+                    if permission not in existing_permissions:
+                        self.add(permission)
 
                 except JSONDecodeError:
                     pass

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_parse_trace.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_parse_trace.py
@@ -57,6 +57,36 @@ def test_parse_trace(tmpdir):
             ),
             ["s3:CreateBucket", "dynamodb:CreateTable"],
         ),
+        (
+            dedent(
+                """
+                {"aws.operation": "DeletePublicAccessBlock","aws.service": "S3"}
+                {"aws.operation": "GetPublicAccessBlock","aws.service": "S3"}
+                {"aws.operation": "PutPublicAccessBlock","aws.service": "S3"}
+                """
+            ),
+            ["s3:PutBucketPublicAccessBlock", "s3:GetBucketPublicAccessBlock"],
+        ),
+        (
+            dedent(
+                """
+                {"tf_resource_type": "aws_s3_bucket_versioning","tf_rpc": "ApplyResourceChange"}
+                {"tf_resource_type": "aws_s3_bucket_server_side_encryption_configuration","tf_rpc": "ApplyResourceChange"}
+                some garbage
+                """
+            ),
+            ["s3:PutBucketVersioning", "s3:PutEncryptionConfiguration"],
+        ),
+        (
+            dedent(
+                """
+                {"tf_resource_type": "aws_s3_bucket_versioning","tf_rpc": "ApplyResourceChange"}
+                {"tf_resource_type": "aws_s3_bucket_versioning","tf_rpc": "ApplyResourceChange"}
+                some garbage
+                """
+            ),
+            ["s3:PutBucketVersioning"],
+        ),
     ],
 )
 def test_parse_trace_permissions_map(tmpdir, trace_content, expected_permissions):

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/test_min_permissions.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/test_min_permissions.py
@@ -45,3 +45,44 @@ def test_simple(tmpdir):
 ]
 """
     )
+
+
+def test_simple_existing(tmpdir):
+    tracefile = tmpdir.join("trace")
+    tracefile.write(
+        dedent(
+            """
+                {"tf_resource_type": "aws_s3_bucket_versioning","tf_rpc": "ApplyResourceChange"}
+                {"tf_resource_type": "aws_s3_bucket_versioning","tf_rpc": "ApplyResourceChange"}
+            """
+        )
+    )
+
+    existing_actions = tmpdir.join("existing.json")
+    existing_actions.write(
+        dedent(
+            """
+            ["s3:PutBucketVersioning"]
+            """
+        )
+    )
+
+    runner = CliRunner()
+    # noinspection PyTypeChecker
+    result = runner.invoke(ih_plan, ["min-permissions", "--existing-actions", str(existing_actions), str(tracefile)])
+    assert result.exit_code == 0
+    print(result.output)
+    assert (
+        result.output
+        == """## Existing 1 actions:
+[
+    "s3:PutBucketVersioning"
+]
+## 0 new action(s):
+[]
+## Old and new actions together excluding duplicates, 1 in total:
+[
+    "s3:PutBucketVersioning"
+]
+"""
+    )

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.4.0'
+build_version '2.4.1'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.0
+current_version = 2.4.1
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.4.0",
+    version="2.4.1",
     zip_safe=False,
 )


### PR DESCRIPTION
- Handle permissions needed by calls like aws_s3_bucket_versioning
- Bump version: 2.4.0 → 2.4.1
