### PR TITLE
Fix allowed action for secrets manager

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.6.1
+:Version: 2.6.2
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.6.1"
+__version__ = "2.6.2"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
@@ -66,6 +66,7 @@ class ActionList:
         "auto scaling": "autoscaling",
         "elastic load balancing v2": "elasticloadbalancing",
         "route 53": "route53",
+        "secrets manager": "secretsmanager",
     }
     PERMISSION_NAMING_MAP = {
         "HeadBucket": "ListBucket",

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.6.1'
+build_version '2.6.2'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.1
+current_version = 2.6.2
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.6.1",
+    version="2.6.2",
     zip_safe=False,
 )


### PR DESCRIPTION
- Fix secrets manager name in allowed actions.
- Bump version: 2.6.1 → 2.6.2
