### PR TITLE
Fix parsing cloudwatch and HeadObject permissions

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.9.2
+:Version: 2.9.3
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.9.2"
+__version__ = "2.9.3"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
@@ -67,9 +67,11 @@ class ActionList:
         "elastic load balancing v2": "elasticloadbalancing",
         "route 53": "route53",
         "secrets manager": "secretsmanager",
+        "cloudwatch logs": "logs",
     }
     PERMISSION_NAMING_MAP = {
         "HeadBucket": "ListBucket",
+        "HeadObject": "GetObject",
         "GetBucketAccelerateConfiguration": "GetAccelerateConfiguration",
         "GetBucketEncryption": "GetEncryptionConfiguration",
         "GetBucketCors": "GetBucketCORS",

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_parse_trace.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_parse_trace.py
@@ -12,6 +12,7 @@ def test_parse_trace(tmpdir):
             """
             {"aws.operation": "PutScalingPolicy","aws.service": "Auto Scaling"}
             {"aws.operation": "DescribePolicies","aws.service": "Auto Scaling"}
+            {  "rpc.method": "DescribeLogGroups", "rpc.service": "CloudWatch Logs"}
             """
         )
     )
@@ -20,6 +21,7 @@ def test_parse_trace(tmpdir):
     assert actions.actions == [
         "autoscaling:DescribePolicies",
         "autoscaling:PutScalingPolicy",
+        "logs:DescribeLogGroups",
     ]
 
 
@@ -30,6 +32,7 @@ def test_parse_trace(tmpdir):
             dedent(
                 """
                 {"aws.operation": "HeadBucket","aws.service": "S3"}
+                {"rpc.method": "HeadObject", "rpc.service": "S3"}
                 {"aws.operation": "GetBucketAccelerateConfiguration","aws.service": "S3"}
                 {"aws.operation": "GetBucketEncryption","aws.service": "S3"}
                 {"aws.operation": "GetBucketCors","aws.service": "S3"}
@@ -46,6 +49,7 @@ def test_parse_trace(tmpdir):
                 "s3:GetLifecycleConfiguration",
                 "s3:GetReplicationConfiguration",
                 "s3:ListBucket",
+                "s3:GetObject",
             ],
         ),
         (

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.9.2'
+build_version '2.9.3'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.2
+current_version = 2.9.3
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.9.2",
+    version="2.9.3",
     zip_safe=False,
 )


### PR DESCRIPTION
- Fix parsing cloudwatch and HeadObject permissions
- Bump version: 2.9.2 → 2.9.3
