### PR TITLE
Add more dependent permissions with `autoscaling:CreateAutoScalingGroup`

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.9.5
+:Version: 2.9.6
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.9.5"
+__version__ = "2.9.6"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
@@ -88,7 +88,12 @@ class ActionList:
     }
     # Some permissions require additional ones.
     REQUIRED_EXTRA_PERMISSIONS_MAP = {
-        "autoscaling:CreateAutoScalingGroup": ["iam:PassRole", "iam:CreateServiceLinkedRole"],
+        "autoscaling:CreateAutoScalingGroup": [
+            "iam:PassRole",
+            "iam:CreateServiceLinkedRole",
+            "ec2:CreateTags",
+            "ec2:RunInstances",
+        ],
         "autoscaling:UpdateAutoScalingGroup": ["iam:PassRole"],
         "elasticloadbalancing:CreateLoadBalancer": ["elasticloadbalancing:AddTags"],
         "iam:AddRoleToInstanceProfile": ["iam:PassRole"],

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_add.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_add.py
@@ -35,6 +35,8 @@ def test_add_with_dependency():
     assert "autoscaling:CreateAutoScalingGroup" in actions.actions
     assert "iam:PassRole" in actions.actions
     assert "iam:CreateServiceLinkedRole" in actions.actions
+    assert "ec2:CreateTags" in actions.actions
+    assert "ec2:RunInstances" in actions.actions
 
 
 def test_add_with_rewrite():

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.9.5'
+build_version '2.9.6'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.5
+current_version = 2.9.6
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.9.5",
+    version="2.9.6",
     zip_safe=False,
 )


### PR DESCRIPTION
- Add more dependent permissions with `autoscaling:CreateAutoScalingGroup`
- Bump version: 2.9.5 → 2.9.6
