### PR TITLE
Make tagging permissions a dependency of create permissions

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.9.6
+:Version: 2.9.7
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.9.6"
+__version__ = "2.9.7"
 
 from logging import getLogger
 

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/__init__.py
@@ -97,9 +97,25 @@ class ActionList:
         "autoscaling:UpdateAutoScalingGroup": ["iam:PassRole"],
         "elasticloadbalancing:CreateLoadBalancer": ["elasticloadbalancing:AddTags"],
         "iam:AddRoleToInstanceProfile": ["iam:PassRole"],
+        "iam:CreateInstanceProfile": ["iam:TagInstanceProfile"],
         "ec2:CreateLaunchTemplate": ["ec2:CreateTags"],
         "ec2:ImportKeyPair": ["ec2:CreateTags"],
         "ec2:RunInstances": ["ec2:CreateTags"],
+        "logs:CreateLogGroup": ["logs:TagResource"],
+        "lambda:CreateFunction": ["lambda:TagResource"],
+        "s3:CreateBucket": ["s3:PutBucketTagging"],
+        "s3:PutObject": [
+            "kms:Decrypt",
+            "kms:CreateGrant",
+            "kms:DescribeKey",
+            "kms:Encrypt",
+            "s3:AbortMultipartUpload",
+            "s3:GetObject",
+            "s3:ListMultipartUploadParts",
+            "s3:PutObjectTagging",
+        ],
+        "events:PutRule": ["events:TagResource"],
+        "events:PutTargets": ["events:TagResource"],
     }
 
     def __init__(self):

--- a/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_add.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_min_permissions/tests/actionlist/test_add.py
@@ -1,3 +1,5 @@
+import pytest
+
 from infrahouse_toolkit.cli.ih_plan.cmd_min_permissions import ActionList
 
 
@@ -28,15 +30,90 @@ def test_add():
     assert "foo" in actions.actions
 
 
-def test_add_with_dependency():
+@pytest.mark.parametrize(
+    "action, dependent_actions",
+    [
+        (
+            "autoscaling:CreateAutoScalingGroup",
+            [
+                "autoscaling:CreateAutoScalingGroup",
+                "iam:PassRole",
+                "iam:CreateServiceLinkedRole",
+                "ec2:CreateTags",
+                "ec2:RunInstances",
+            ],
+        ),
+        (
+            "logs:CreateLogGroup",
+            [
+                "logs:CreateLogGroup",
+                "logs:TagResource",
+            ],
+        ),
+        (
+            "lambda:CreateFunction",
+            [
+                "lambda:CreateFunction",
+                "lambda:TagResource",
+            ],
+        ),
+        (
+            "s3:PutObject",
+            [
+                "kms:Decrypt",
+                "kms:CreateGrant",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:AbortMultipartUpload",
+                "s3:GetObject",
+                "s3:ListMultipartUploadParts",
+            ],
+        ),
+        (
+            "events:PutRule",
+            [
+                "events:PutRule",
+                "events:TagResource",
+            ],
+        ),
+        (
+            "events:PutTargets",
+            [
+                "events:PutTargets",
+                "events:TagResource",
+            ],
+        ),
+        (
+            "iam:CreateInstanceProfile",
+            [
+                "iam:CreateInstanceProfile",
+                "iam:TagInstanceProfile",
+            ],
+        ),
+        (
+            "iam:CreateInstanceProfile",
+            [
+                "iam:CreateInstanceProfile",
+                "iam:TagInstanceProfile",
+            ],
+        ),
+        (
+            "s3:CreateBucket",
+            [
+                "s3:CreateBucket",
+                "s3:PutBucketTagging",
+            ],
+        ),
+    ],
+)
+def test_add_with_dependency(action, dependent_actions):
     actions = ActionList()
-    actions.add("autoscaling:CreateAutoScalingGroup")
+    actions.add(action)
 
-    assert "autoscaling:CreateAutoScalingGroup" in actions.actions
-    assert "iam:PassRole" in actions.actions
-    assert "iam:CreateServiceLinkedRole" in actions.actions
-    assert "ec2:CreateTags" in actions.actions
-    assert "ec2:RunInstances" in actions.actions
+    for dependency in dependent_actions:
+        assert dependency in actions.actions
 
 
 def test_add_with_rewrite():

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.9.6'
+build_version '2.9.7'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.6
+current_version = 2.9.7
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.9.6",
+    version="2.9.7",
     zip_safe=False,
 )


### PR DESCRIPTION
- Make tagging permissions a dependency of create permissions
- Bump version: 2.9.6 → 2.9.7
