### PR TITLE
[ih-registry] fix hardcoded module name

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.16.0
+:Version: 2.16.1
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.16.0"
+__version__ = "2.16.1"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/cli/ih_registry/cmd_upload/__init__.py
+++ b/infrahouse_toolkit/cli/ih_registry/cmd_upload/__init__.py
@@ -80,7 +80,7 @@ def cmd_upload(**kwargs):
     url = f"{kwargs['registry_url']}/terraform/modules/v1/{module_name}/{module_version}"
     LOG.debug("Uploading to %s", url)
     # 1 / 0
-    api_key = kwargs["deploy_key"] or _detect_api_key(kwargs["dynamodb_table"])
+    api_key = kwargs["deploy_key"] or _detect_api_key(kwargs["dynamodb_table"], module_name)
     with TemporaryDirectory() as tmp_dir:
         LOG.debug("Archiving directory %s into directory %s", module_path, tmp_dir)
         archive_name = make_archive(osp.join(tmp_dir, "module"), "zip", kwargs["module_path"])
@@ -93,13 +93,13 @@ def cmd_upload(**kwargs):
             LOG.info("Server response: code %d, body: %s", response.status_code, response.text or "empty")
 
 
-def _detect_api_key(dynamodb_table: str) -> str:
+def _detect_api_key(dynamodb_table: str, module_name: str) -> str:
     client = boto3.client("dynamodb")
     response = client.get_item(
         TableName=dynamodb_table,
         Key={
             "id": {
-                "S": "infrahouse-cloud-init-aws",
+                "S": "-".join(module_name.split("/")),
             }
         },
     )

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.16.0'
+build_version '2.16.1'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.16.0
+current_version = 2.16.1
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.16.0",
+    version="2.16.1",
     zip_safe=False,
 )


### PR DESCRIPTION
- [ih-registry] fix hardcoded module name
- Bump version: 2.16.0 → 2.16.1
