### PR TITLE
Remove debug lines from Terraform output

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.17.0
+:Version: 2.17.1
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.17.0"
+__version__ = "2.17.1"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/cli/ih_plan/cmd_publish/__init__.py
+++ b/infrahouse_toolkit/cli/ih_plan/cmd_publish/__init__.py
@@ -13,6 +13,7 @@ from infrahouse_toolkit.cli.lib import get_backend_key, get_bucket
 from infrahouse_toolkit.terraform import RunOutput, TFStatus, parse_plan
 from infrahouse_toolkit.terraform.backends import TFS3Backend
 from infrahouse_toolkit.terraform.githubpr import GitHubPR
+from infrahouse_toolkit.terraform.status import strip_lines
 
 
 @click.command(name="publish")
@@ -54,8 +55,8 @@ def cmd_publish(*args, **kwargs):
     with open(kwargs["tf_plan_stdout"], encoding=DEFAULT_OPEN_ENCODING) as fp_stdout, open(
         kwargs["tf_plan_stderr"], encoding=DEFAULT_OPEN_ENCODING
     ) as fp_stderr:
-        stdout = fp_stdout.read()
-        stderr = fp_stderr.read()
+        stdout = strip_lines(fp_stdout.read(), "::debug::")
+        stderr = strip_lines(fp_stderr.read(), "::debug::")
 
         counts, resources = parse_plan(stdout)
         backend = TFS3Backend(

--- a/infrahouse_toolkit/terraform/status.py
+++ b/infrahouse_toolkit/terraform/status.py
@@ -15,7 +15,6 @@ from infrahouse_toolkit.terraform.backends.tfbackend import TFBackend
 RunResult = namedtuple("RunResult", "add change destroy")
 RunOutput = namedtuple("RunOutput", "stdout stderr")
 
-
 RE_NO_COLOR = r"""
     \x1B  # ESC
     (?:   # 7-bit C1 Fe (except CSI)
@@ -36,6 +35,20 @@ def decolor(text: str) -> str:
         return ansi_escape.sub("", text)
 
     return text
+
+
+def strip_lines(src: str, pattern: str) -> str:
+    """
+    Remove lines starting with a string ``pattern``.
+
+    :param src: Input text
+    :type src: str
+    :param pattern: A string. When a line in the input text starts with this string - skip it.
+    :type pattern: str
+    :return: Stripped text.
+    :rtype: str
+    """
+    return "\n".join([x for x in src.splitlines() if not x.startswith(pattern)]) + ("\n" if src[-1] == "\n" else "")
 
 
 class TFStatus:

--- a/infrahouse_toolkit/terraform/tests/test_strip_lines.py
+++ b/infrahouse_toolkit/terraform/tests/test_strip_lines.py
@@ -1,0 +1,36 @@
+from textwrap import dedent
+
+import pytest
+
+from infrahouse_toolkit.terraform.status import strip_lines
+
+
+@pytest.mark.parametrize(
+    "in_text, pattern, out_text",
+    [
+        ("foo", "bar", "foo"),
+        (
+            dedent(
+                """
+                test line 1
+                test line 2
+                test line 3
+                ::debug::Terraform exited with code 0.
+                ::debug::stdout: module.jumphost
+                ::debug::stderr:
+                ::debug::exitcode: 0
+                """
+            ),
+            "::debug::",
+            dedent(
+                """
+                test line 1
+                test line 2
+                test line 3
+                """
+            ),
+        ),
+    ],
+)
+def test_strip_lines(in_text, pattern, out_text):
+    assert strip_lines(in_text, pattern) == out_text

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.17.0'
+build_version '2.17.1'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.17.0
+current_version = 2.17.1
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.17.0",
+    version="2.17.1",
     zip_safe=False,
 )


### PR DESCRIPTION
- Remove debug lines from Terraform output
- Bump version: 2.17.0 → 2.17.1
