### PR TITLE
Fix strip_lines() if input is empty

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.17.1
+:Version: 2.17.2
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.17.1"
+__version__ = "2.17.2"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/terraform/status.py
+++ b/infrahouse_toolkit/terraform/status.py
@@ -48,7 +48,11 @@ def strip_lines(src: str, pattern: str) -> str:
     :return: Stripped text.
     :rtype: str
     """
-    return "\n".join([x for x in src.splitlines() if not x.startswith(pattern)]) + ("\n" if src[-1] == "\n" else "")
+    return (
+        "\n".join([x for x in src.splitlines() if not x.startswith(pattern)]) + ("\n" if src[-1] == "\n" else "")
+        if src
+        else src
+    )
 
 
 class TFStatus:

--- a/infrahouse_toolkit/terraform/tests/test_strip_lines.py
+++ b/infrahouse_toolkit/terraform/tests/test_strip_lines.py
@@ -9,6 +9,7 @@ from infrahouse_toolkit.terraform.status import strip_lines
     "in_text, pattern, out_text",
     [
         ("foo", "bar", "foo"),
+        ("", "bar", ""),
         (
             dedent(
                 """

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.17.1'
+build_version '2.17.2'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.17.1
+current_version = 2.17.2
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.17.1",
+    version="2.17.2",
     zip_safe=False,
 )


### PR DESCRIPTION
- Fix strip_lines() if input is empty
- Bump version: 2.17.1 → 2.17.2
