### PR TITLE
Simplify log format in non-verbose mode

### DIFF
--- a/infrahouse_toolkit/cli/ih_secrets/__init__.py
+++ b/infrahouse_toolkit/cli/ih_secrets/__init__.py
@@ -5,6 +5,7 @@
 
     See ``ih-secrets --help`` for more details.
 """
+
 import sys
 from logging import getLogger
 
@@ -59,11 +60,9 @@ LOG = getLogger(__name__)
 )
 @click.version_option()
 @click.pass_context
-def ih_secrets(ctx, **kwargs):
+def ih_secrets(ctx, verbose, debug, aws_profile, aws_region):
     """AWS EC2 helpers."""
-    setup_logging(debug=kwargs["debug"], quiet=not kwargs["verbose"])
-    aws_profile = kwargs["aws_profile"]
-    aws_region = kwargs["aws_region"]
+    setup_logging(debug=debug, quiet=not verbose)
     aws_config = AWSConfig()
     aws_session = None
     try:
@@ -88,7 +87,7 @@ def ih_secrets(ctx, **kwargs):
 
     try:
         ctx.obj = {
-            "debug": kwargs["debug"],
+            "debug": debug,
             "secretsmanager_client": get_aws_client("secretsmanager", aws_profile, aws_region, session=aws_session),
             "aws_config": aws_config,
         }

--- a/infrahouse_toolkit/logging.py
+++ b/infrahouse_toolkit/logging.py
@@ -1,6 +1,7 @@
 """
 InfraHouse Toolkit Logging.
 """
+
 import logging
 import sys
 
@@ -21,6 +22,8 @@ def setup_logging(logger=None, debug=False, quiet=False):  # pragma: no cover
     """Configures logging for the module"""
     logger = logger or logging.getLogger()
     fmt_str = "%(asctime)s: %(levelname)s: %(name)s:%(module)s.%(funcName)s():%(lineno)d: %(message)s"
+    quiet_fmt_str = "%(levelname)s: %(message)s"
+    fmt_str = quiet_fmt_str if quiet else fmt_str
 
     console_handler = logging.StreamHandler(stream=sys.stdout)
     console_handler.addFilter(LessThanFilter(logging.WARNING))


### PR DESCRIPTION
When running commands in non-verbose mode CLI tool is, well, too verbose in terms of logging output.

I know its a matter of preference, but from the CLI user perspective getting timestamps, tool files and line numbers don't carry too much value to me.
For tool debugging purposes - sure. I can get why we want to display more info (so we know at which exact code point tool generated log). But in non-verbose mode that only adds unnecessary clutter to log output:

Before:
```bash
❯ ih-secrets list
2024-06-09 22:45:28,613: ERROR: infrahouse_toolkit.cli.ih_secrets:__init__.ih_secrets():80: Try to run ih-secrets with --aws-profile option.
2024-06-09 22:45:28,614: ERROR: infrahouse_toolkit.cli.ih_secrets:__init__.ih_secrets():81: Available profiles:
        default
        production
        sandbox
```

After:
```bash
❯ ih-secrets list
ERROR: Try to run ih-secrets with --aws-profile option.
ERROR: Available profiles:
        default
        production
        sandbox
```