### PR TITLE
ih-secrets list doesn't work with default AWS profile

### DIFF
--- a/infrahouse_toolkit/aws/config.py
+++ b/infrahouse_toolkit/aws/config.py
@@ -1,6 +1,7 @@
 """
 Module for AWSConfig class.
 """
+
 from configparser import ConfigParser
 from os import path as osp
 
@@ -95,4 +96,4 @@ class AWSConfig:
 
     @staticmethod
     def _get_section(profile_name):
-        return profile_name if profile_name == "default" else f"profile {profile_name}"
+        return f"profile {profile_name}"

--- a/infrahouse_toolkit/aws/config.py
+++ b/infrahouse_toolkit/aws/config.py
@@ -96,4 +96,4 @@ class AWSConfig:
 
     @staticmethod
     def _get_section(profile_name):
-        return f"profile {profile_name}"
+        return profile_name if profile_name == "default" else f"profile {profile_name}"

--- a/infrahouse_toolkit/aws/tests/config/test_get_account_id.py
+++ b/infrahouse_toolkit/aws/tests/config/test_get_account_id.py
@@ -6,7 +6,7 @@ from infrahouse_toolkit.aws import AWSConfig
 
 CONTENT = dedent(
     """
-    [profile default]
+    [default]
     sso_account_id = 123
 
     [profile foo]

--- a/infrahouse_toolkit/aws/tests/config/test_get_account_id.py
+++ b/infrahouse_toolkit/aws/tests/config/test_get_account_id.py
@@ -6,7 +6,7 @@ from infrahouse_toolkit.aws import AWSConfig
 
 CONTENT = dedent(
     """
-    [default]
+    [profile default]
     sso_account_id = 123
 
     [profile foo]

--- a/infrahouse_toolkit/cli/ih_secrets/__init__.py
+++ b/infrahouse_toolkit/cli/ih_secrets/__init__.py
@@ -29,20 +29,6 @@ AWS_DEFAULT_REGION = "us-west-1"
 LOG = getLogger(__name__)
 
 
-def _resolve_aws_profiles():
-    """
-    Get a list of AWS profiles.
-
-    :return: List of AWS profiles.
-    :rtype: list
-    """
-    profiles = AWSConfig().profiles
-    if not profiles:
-        LOG.error("No AWS profiles found. Please configure AWS CLI.")
-        sys.exit(1)
-    return profiles
-
-
 @click.group()
 @click.option(
     "--debug",
@@ -61,7 +47,7 @@ def _resolve_aws_profiles():
 @click.option(
     "--aws-profile",
     help="AWS profile name for authentication.",
-    type=click.Choice(_resolve_aws_profiles()),
+    type=click.Choice(AWSConfig().profiles),
     default="default",
     show_default=True,
 )

--- a/infrahouse_toolkit/cli/ih_secrets/__init__.py
+++ b/infrahouse_toolkit/cli/ih_secrets/__init__.py
@@ -5,6 +5,7 @@
 
     See ``ih-secrets --help`` for more details.
 """
+
 import sys
 from logging import getLogger
 
@@ -28,6 +29,20 @@ AWS_DEFAULT_REGION = "us-west-1"
 LOG = getLogger(__name__)
 
 
+def _resolve_aws_profiles():
+    """
+    Get a list of AWS profiles.
+
+    :return: List of AWS profiles.
+    :rtype: list
+    """
+    profiles = AWSConfig().profiles
+    if not profiles:
+        LOG.error("No AWS profiles found. Please configure AWS CLI.")
+        sys.exit(1)
+    return profiles
+
+
 @click.group()
 @click.option(
     "--debug",
@@ -46,8 +61,8 @@ LOG = getLogger(__name__)
 @click.option(
     "--aws-profile",
     help="AWS profile name for authentication.",
-    type=click.Choice(AWSConfig().profiles),
-    default=None,
+    type=click.Choice(_resolve_aws_profiles()),
+    default="default",
     show_default=True,
 )
 @click.option(


### PR DESCRIPTION
`ih-secrets list` doesn't currently work when profile is not explicitly specified:

```
❯ ih-secrets list
2024-06-09 13:58:05,992: ERROR: infrahouse_toolkit.cli.ih_secrets:__init__.ih_secrets():80: Try to run ih-secrets with --aws-profile option.
2024-06-09 13:58:05,992: ERROR: infrahouse_toolkit.cli.ih_secrets:__init__.ih_secrets():81: Available profiles:
	default
	production
	sandbox
```

2 problems there:
1. Default CLI param for "aws_profile" is set to None which makes tool think profile is not present at all
2. When "default" set as profile, tool can't resolve its config since config section is resolved as "default" instead of "profile default"