### PR TITLE
Fix README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. toctree::
-    :maxdepth: 4
-
 ==================
 InfraHouse Toolkit
 ==================

--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.25.0
+:Version: 2.25.1
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.25.0"
+__version__ = "2.25.1"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.25.0'
+build_version '2.25.1'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.25.0
+current_version = 2.25.1
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.25.0",
+    version="2.25.1",
     zip_safe=False,
 )


### PR DESCRIPTION
- Fix README
- Bump version: 2.25.0 → 2.25.1

Pypi complains about

```
 line 1: Error: Unknown directive type "toctree".                       
                                                                                
         .. toctree::                                                           
             :maxdepth: 4            
```

it doesn't work as expected anyway, so removing.
