### PR TITLE
Add GitHub Action that generates a relase on a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+---
+# Credit: https://stackoverflow.com/a/75679739/3209896
+name: "Create release"
+
+on:  # yamllint disable-line rule:truthy
+    push:
+        tags:
+            - "*"
+
+permissions:
+    contents: write
+
+jobs:
+    release:
+        name: "Release pushed tag"
+        runs-on: "ubuntu-22.04"
+        steps:
+            - name: "Create release"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  tag: ${{ github.ref_name }}
+              run: |
+                  gh release create "$tag" \
+                      --repo="$GITHUB_REPOSITORY" \
+                      --title="${GITHUB_REPOSITORY#*/} ${tag#v}" \
+                      --generate-notes


### PR DESCRIPTION
When a new tag is pushed, the GitHub Action creates a release.
