### PR TITLE
Add scripts for building infrahouse-toolkit on arm64

### DIFF
--- a/omnibus-infrahouse-toolkit/build-arm64.sh
+++ b/omnibus-infrahouse-toolkit/build-arm64.sh
@@ -10,7 +10,7 @@ do
     docker run --rm \
         --privileged \
         $(ih-aws --aws-profile AWSAdministratorAccess-493370826424 credentials --docker) \
-        -v $PWD:/infrahouse-toolkit \
+        -v "$PWD":/infrahouse-toolkit \
         -w /infrahouse-toolkit \
         ubuntu:noble bash /infrahouse-toolkit/omnibus-infrahouse-toolkit/upload-arm64.sh $os
 done

--- a/omnibus-infrahouse-toolkit/build-arm64.sh
+++ b/omnibus-infrahouse-toolkit/build-arm64.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eux
+
+for os in "noble" "jammy" "focal"
+do
+    export OS_VERSION=$os
+    make clean
+    make package
+    docker run --rm \
+        --privileged \
+        $(ih-aws --aws-profile AWSAdministratorAccess-493370826424 credentials --docker) \
+        -v $PWD:/infrahouse-toolkit \
+        -w /infrahouse-toolkit \
+        ubuntu:noble bash /infrahouse-toolkit/omnibus-infrahouse-toolkit/upload-arm64.sh $os
+done

--- a/omnibus-infrahouse-toolkit/upload-arm64.sh
+++ b/omnibus-infrahouse-toolkit/upload-arm64.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eux
+codename=$1
+
+# Install dependencies
+
+apt-get update
+apt-get -y install gpg lsb-release curl
+
+
+# Add a GPG public key to verify InfraHouse packages
+
+mkdir -p /etc/apt/cloud-init.gpg.d/
+curl  -fsSL "https://release-$(lsb_release -cs).infrahouse.com/DEB-GPG-KEY-release-$(lsb_release -cs).infrahouse.com" \
+    | gpg --dearmor -o /etc/apt/cloud-init.gpg.d/infrahouse.gpg
+
+
+# Add the InfraHouse repository source
+
+echo "deb [signed-by=/etc/apt/cloud-init.gpg.d/infrahouse.gpg] https://release-$(lsb_release -cs).infrahouse.com/ $(lsb_release -cs) main" \
+    > /etc/apt/sources.list.d/infrahouse.list
+
+apt-get update
+
+apt-get -y install infrahouse-toolkit
+
+ih-s3-reprepro \
+    --debug \
+    --bucket infrahouse-release-"$codename" \
+    --gpg-key-secret-id packager-key-"$codename" \
+    --gpg-passphrase-secret-id packager-passphrase-"$codename" \
+    includedeb \
+    "$codename" \
+    omnibus-infrahouse-toolkit/pkg/infrahouse-toolkit_*.deb


### PR DESCRIPTION
Well, I couldn't install docker on a macos-14 GitHub Actions runner.
But I still need infrahouse-toolkit packages on arm64.
As a workaround, I created a `build-arm64.sh` build script. It's supposed to run on a MacOS laptop with arm64 chip.
The script builds the package for Ubuntu focal, jammy, and noble and uploads the package to https://release-${OS_VERSION}.infrahouse.com/
