### PR TITLE
`ih-github runner` supports --registration-token-secret

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.27.0
+:Version: 2.28.0
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.27.0"
+__version__ = "2.28.0"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/cli/ih_github/cmd_runner/__init__.py
+++ b/infrahouse_toolkit/cli/ih_github/cmd_runner/__init__.py
@@ -28,6 +28,7 @@ LOG = logging.getLogger()
 )
 @click.option("--github-token", help="Personal access token for GitHub.", envvar="GITHUB_TOKEN", show_default=True)
 @click.option("--github-token-secret", help="Read GitHub token from AWS secret.")
+@click.option("--registration-token-secret", help="AWS secret name with a registration token.", default=None)
 @click.option(
     "--org",
     help="GitHub organization",
@@ -47,7 +48,11 @@ def cmd_runner(ctx, *args, **kwargs):
     else:
         github_token = kwargs["github_token"]
 
-    ctx.obj = {"github_token": github_token, "org": kwargs["org"]}
+    ctx.obj = {
+        "github_token": github_token,
+        "org": kwargs["org"],
+        "registration_token_secret": kwargs["registration_token_secret"],
+    }
 
 
 for cmd in [cmd_list, cmd_register, cmd_deregister, cmd_is_registered, cmd_download]:

--- a/infrahouse_toolkit/cli/ih_github/cmd_runner/cmd_register/__init__.py
+++ b/infrahouse_toolkit/cli/ih_github/cmd_runner/cmd_register/__init__.py
@@ -11,8 +11,11 @@ from os import path as osp
 from subprocess import run
 from tempfile import gettempdir
 
+import boto3
 import click
 from requests import post
+
+from infrahouse_toolkit.cli.ih_secrets.cmd_get import get_secret
 
 LOG = logging.getLogger()
 AR_URL = "https://github.com/actions/runner/releases/download/v2.314.1/actions-runner-linux-x64-2.314.1.tar.gz"
@@ -41,17 +44,24 @@ def cmd_register(ctx, **kwargs):
     """
     github_token = ctx.obj["github_token"]
     org = ctx.obj["org"]
-    response = post(
-        f"https://api.github.com/orgs/{org}/actions/runners/registration-token",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {github_token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-        timeout=30,
-    )
-    response.raise_for_status()
-    token = response.json()["token"]
+    registration_token_secret = ctx.obj["registration_token_secret"]
+
+    if registration_token_secret:
+        token = get_secret(boto3.client("secretsmanager"), registration_token_secret)
+
+    else:
+        response = post(
+            f"https://api.github.com/orgs/{org}/actions/runners/registration-token",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {github_token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        token = response.json()["token"]
+
     cmd = [
         osp.join(kwargs["actions_runner_code_path"], "config.sh"),
         "--url",

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.27.0'
+build_version '2.28.0'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.27.0
+current_version = 2.28.0
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.27.0",
+    version="2.28.0",
     zip_safe=False,
 )


### PR DESCRIPTION
- `ih-github runner` Supports --registration-token-secret
- Bump version: 2.27.0 → 2.28.0
