### PR TITLE
Pin cryptography to < 43.0.0

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.28.0
+:Version: 2.28.1
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.28.0"
+__version__ = "2.28.1"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.28.0'
+build_version '2.28.1'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ botocore ~= 1.29
 certbot ~= 2.9
 certbot-dns-route53 ~= 2.9
 click ~= 8.1
+cryptography < 43.0.0 # Pinning until https://github.com/certbot/certbot/issues/9967 is fixed.
 diskcache ~= 5.6
 elasticsearch ~= 8.12.0
 pyhcl ~= 0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.28.0
+current_version = 2.28.1
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.28.0",
+    version="2.28.1",
     zip_safe=False,
 )


### PR DESCRIPTION
Version 43 produces a deprecation warning. certbot project is unlikely to migrate to `this_update_utc` any time soon.
See discussion in https://github.com/certbot/certbot/issues/9967

Pinning the cryptography version as a temporary measure to mute the cron noise.
