### PR TITLE
Add command ih-aws ecs wait-services-stable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ A collection of tools for building infrastructure.
 ``ih-aws``: AWS helpers
 -----------------------
 
-The command is supposed to work with AWS. As of now, only one commands is supported - ``ih-aws credentials``.
+The command group to work with AWS services.
 
 ``ih-aws credentials``: retrieve temporary AWS credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -111,6 +111,28 @@ then you can get credentials for a specific profile.
         "Arn": "arn:aws:sts::303467602807:assumed-role/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14/aleks"
     }
 
+``ih-aws ecs``: ECS helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ ih-aws ecs wait-services-stable --help
+    Usage: ih-aws ecs wait-services-stable [OPTIONS]
+
+      Wait up to --timeout seconds until all specified services in an ECS cluster
+      become stable.
+
+      The service is considered stable when there is only one deployment for it
+      and number of running tasks is equal to desired number tasks.
+
+    Options:
+      --cluster TEXT          ECS cluster name that runs requested services.
+                              [required]
+      --service TEXT          ECS service name that we wait to become stable.
+                              Multiple services can be specified.  [required]
+      --wait-timeout INTEGER  Time in seconds to wait until all services become
+                              stable.  [default: 1200]
+      --help                  Show this message and exit.
 
 ``ih-certbot``: a bundled certbot
 ---------------------------------

--- a/docs/infrahouse_toolkit.cli.ih_aws.cmd_ecs.cmd_wait_services_stable.rst
+++ b/docs/infrahouse_toolkit.cli.ih_aws.cmd_ecs.cmd_wait_services_stable.rst
@@ -1,0 +1,10 @@
+infrahouse\_toolkit.cli.ih\_aws.cmd\_ecs.cmd\_wait\_services\_stable package
+============================================================================
+
+Module contents
+---------------
+
+.. automodule:: infrahouse_toolkit.cli.ih_aws.cmd_ecs.cmd_wait_services_stable
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/infrahouse_toolkit.cli.ih_aws.cmd_ecs.rst
+++ b/docs/infrahouse_toolkit.cli.ih_aws.cmd_ecs.rst
@@ -1,0 +1,18 @@
+infrahouse\_toolkit.cli.ih\_aws.cmd\_ecs package
+================================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   infrahouse_toolkit.cli.ih_aws.cmd_ecs.cmd_wait_services_stable
+
+Module contents
+---------------
+
+.. automodule:: infrahouse_toolkit.cli.ih_aws.cmd_ecs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/infrahouse_toolkit.cli.ih_aws.rst
+++ b/docs/infrahouse_toolkit.cli.ih_aws.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    infrahouse_toolkit.cli.ih_aws.cmd_credentials
+   infrahouse_toolkit.cli.ih_aws.cmd_ecs
 
 Module contents
 ---------------

--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.29.0
+:Version: 2.30.0
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.29.0"
+__version__ = "2.30.0"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/cli/ih_aws/__init__.py
+++ b/infrahouse_toolkit/cli/ih_aws/__init__.py
@@ -15,6 +15,7 @@ from botocore.exceptions import NoRegionError
 from infrahouse_toolkit.aws import get_aws_session
 from infrahouse_toolkit.aws.config import AWSConfig
 from infrahouse_toolkit.cli.ih_aws.cmd_credentials import cmd_credentials
+from infrahouse_toolkit.cli.ih_aws.cmd_ecs import cmd_ecs
 from infrahouse_toolkit.logging import setup_logging
 
 AWS_DEFAULT_REGION = "us-west-1"
@@ -74,6 +75,7 @@ def ih_aws(ctx, **kwargs):
 
 for cmd in [
     cmd_credentials,
+    cmd_ecs,
 ]:
     # noinspection PyTypeChecker
     ih_aws.add_command(cmd)

--- a/infrahouse_toolkit/cli/ih_aws/cmd_credentials/__init__.py
+++ b/infrahouse_toolkit/cli/ih_aws/cmd_credentials/__init__.py
@@ -54,6 +54,6 @@ def cmd_credentials(ctx, docker, export):
 
     except ClientError as err:
         LOG.exception(err)
-        LOG.error("Try to run ih-secrets with --aws-profile option.")
+        LOG.error("Try to run ih-aws with --aws-profile option.")
         LOG.error("Available profiles:\n\t%s", "\n\t".join(aws_config.profiles))
         sys.exit(1)

--- a/infrahouse_toolkit/cli/ih_aws/cmd_ecs/__init__.py
+++ b/infrahouse_toolkit/cli/ih_aws/cmd_ecs/__init__.py
@@ -1,0 +1,31 @@
+"""
+.. topic:: ``ih-aws ecs``
+
+    A ``ih-aws ecs`` subcommand.
+
+    See ``ih-aws ecs --help`` for more details.
+"""
+
+from logging import getLogger
+
+import click
+
+from infrahouse_toolkit.cli.ih_aws.cmd_ecs.cmd_wait_services_stable import (
+    cmd_wait_services_stable,
+)
+
+LOG = getLogger(__name__)
+
+
+@click.group(name="ecs")
+def cmd_ecs():
+    """
+    AWS ECS Commands.
+    """
+
+
+for cmd in [
+    cmd_wait_services_stable,
+]:
+    # noinspection PyTypeChecker
+    cmd_ecs.add_command(cmd)

--- a/infrahouse_toolkit/cli/ih_aws/cmd_ecs/cmd_wait_services_stable/__init__.py
+++ b/infrahouse_toolkit/cli/ih_aws/cmd_ecs/cmd_wait_services_stable/__init__.py
@@ -1,0 +1,99 @@
+"""
+.. topic:: ``ih-aws ecs``
+
+    A ``ih-aws ecs`` subcommand.
+
+    See ``ih-aws ecs --help`` for more details.
+"""
+
+import sys
+import time
+from logging import getLogger
+
+import click
+from botocore.exceptions import ClientError
+
+from infrahouse_toolkit.aws import get_aws_client
+
+LOG = getLogger(__name__)
+
+
+@click.command(name="wait-services-stable")
+@click.option("--cluster", help="ECS cluster name that runs requested services.", required=True)
+@click.option(
+    "--service",
+    help="ECS service name that we wait to become stable. Multiple services can be specified.",
+    required=True,
+    multiple=True,
+)
+@click.option(
+    "--wait-timeout",
+    help="Time in seconds to wait until all services become stable.",
+    default=20 * 60,
+    show_default=True,
+)
+@click.pass_context
+def cmd_wait_services_stable(ctx, **kwargs):
+    """
+    Wait up to --timeout seconds until all specified services in an ECS cluster
+    become stable.
+
+    The service is considered stable when there is only one deployment for it
+    and number of running tasks is equal to desired number tasks.
+    """
+    aws_config = ctx.obj["aws_config"]
+    aws_profile = ctx.obj["aws_profile"]
+    cluster = kwargs["cluster"]
+    services = kwargs["service"]
+    wait_timeout = kwargs["wait_timeout"]
+    try:
+        aws_session = ctx.obj["aws_session"]
+        response = get_aws_client(
+            "sts", aws_profile, aws_config.get_region(aws_profile), session=aws_session
+        ).get_caller_identity()
+        LOG.debug("Connected to AWS as %s", response["Arn"])
+        ecs_client = get_aws_client("ecs", aws_profile, aws_config.get_region(aws_profile), session=aws_session)
+        now = time.time()
+        _wait_for_services(ecs_client, cluster, services, start_time=now, end_time=now + wait_timeout)
+
+    except ClientError as err:
+        LOG.exception(err)
+        LOG.error("Try to run ih-aws with --aws-profile option.")
+        LOG.error("Available profiles:\n\t%s", "\n\t".join(aws_config.profiles))
+        sys.exit(1)
+
+
+def _wait_for_services(ecs_client, cluster, services, start_time, end_time):
+    sleep_time = 15
+    while time.time() < end_time:
+        response = ecs_client.describe_services(cluster=cluster, services=list(services))
+
+        all_services_stable = True
+        for service in response["services"]:
+            n_deployments = len(service["deployments"])
+            LOG.info("Service: %s, deployments = %d", service["serviceName"], n_deployments)
+
+            for deployment in service["deployments"]:
+                LOG.info(
+                    "Service: %s, deployment = %s (%s), running = %d, desired = %s",
+                    service["serviceName"],
+                    deployment["id"],
+                    deployment["status"],
+                    deployment["runningCount"],
+                    deployment["desiredCount"],
+                )
+                if deployment["runningCount"] != deployment["desiredCount"]:
+                    all_services_stable = False
+
+            if n_deployments != 1:
+                all_services_stable = False
+
+        if all_services_stable:
+            LOG.info("Services %s are stable", ",".join(services))
+            sys.exit(0)
+        else:
+            LOG.info("Services are not stable yet. Waiting %s seconds", sleep_time)
+            time.sleep(sleep_time)
+
+    LOG.error("Services %s didn't become stable after %s seconds", ",".join(services), end_time - start_time)
+    sys.exit(1)

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.29.0'
+build_version '2.30.0'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.29.0
+current_version = 2.30.0
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.29.0",
+    version="2.30.0",
     zip_safe=False,
 )


### PR DESCRIPTION
The command is identical to `aws ecs wait services-stable` plus allows to configure wait timeout (in AWS cli it's hardcoded to 10 minutes) and shows a progress.

- Add command ih-aws ecs wait-services-stable
- Bump version: 2.29.0 → 2.30.0
