### PR TITLE
New ih-elastic commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -381,7 +381,7 @@ The ``ih-elastic`` command works with an Elasticsearch cluster.
       --password-secret TEXT          AWS secretsmanager secret id with the
                                       password.
       --es-protocol TEXT              Elasticsearch protocol  [default: http]
-      --es-host TEXT                  Elasticsearch host  [default: 10.1.2.145]
+      --es-host TEXT                  Elasticsearch host  [default: 127.0.1.1]
       --es-port INTEGER               Elasticsearch port  [default: 9200]
       --format [text|json|cbor|yaml|smile]
                                       Output format
@@ -389,14 +389,15 @@ The ``ih-elastic`` command works with an Elasticsearch cluster.
 
     Commands:
       cat             Compact and aligned text (CAT) APIs.
+      cluster         Cluster level operations.
       cluster-health  Connect to Elasticsearch host and print the cluster...
       passwd          Change password for Elasticsearch user.
       snapshots       Work with snapshots.
 
+``ih-elastic cluster-health``: Show cluster health
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-My favorite commands.
-
-``ih-elastic cluster-health`` shows a cluster health. The command is supposed to be run on an Elasticsearch node.
+``ih-elastic cluster-health`` shows the cluster health. The command is supposed to be run on an Elasticsearch node.
 
 .. code-block:: bash
 
@@ -421,6 +422,43 @@ My favorite commands.
         "active_shards_percent_as_number": 100.0
     }
 
+``ih-elastic cluster allocation-explain``: Explain allocation problems
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ ih-elastic cluster allocation-explain --help
+    Usage: ih-elastic cluster allocation-explain [OPTIONS]
+
+      Provides explanations for shard allocations in the cluster.
+
+    Options:
+      --index TEXT           Specifies the name of the index that you would like
+                             an explanation for. Run ih-elastic cat shards to get
+                             a list.
+      --shard INTEGER        Specifies the ID of the shard that you would like an
+                             explanation for. Run ih-elastic cat shards to get a
+                             list.
+      --primary / --replica  If --primary, returns explanation for the primary
+                             shard for the given shard ID.
+      --help                 Show this message and exit.
+
+
+``ih-elastic cat shards``: List shards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ ih-elastic cat shards --help
+    Usage: ih-elastic cat shards [OPTIONS]
+
+      Provides a detailed view of shard allocation on nodes.
+
+    Options:
+      --help  Show this message and exit.
+
+``ih-elastic cat snapshots``: Shows backup copies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``ih-elastic cat snapshots`` shows available backup copies. It also has to be run on an Elasticsearch node.
 
@@ -438,6 +476,9 @@ My favorite commands.
     elastic-2024-02-21_11-44-02.921604 backups    SUCCESS 1708515842  11:44:02   1708515844 11:44:04     1.4s      36                36             0           36
     elastic-2024-02-21_12-37-02.628985 backups    SUCCESS 1708519022  12:37:02   1708519023 12:37:03    800ms      36                36             0           36
 
+
+``ih-elastic snapshots``: Create or restore snapshots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``ih-elastic snapshots`` can take or restore a snapshot.
 

--- a/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_shards.rst
+++ b/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_shards.rst
@@ -1,0 +1,10 @@
+infrahouse\_toolkit.cli.ih\_elastic.cmd\_cat.cmd\_shards package
+================================================================
+
+Module contents
+---------------
+
+.. automodule:: infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_shards
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cat.rst
+++ b/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cat.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_repositories
+   infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_shards
    infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_snapshots
 
 Module contents

--- a/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cluster.cmd_allocation_explain.rst
+++ b/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cluster.cmd_allocation_explain.rst
@@ -1,0 +1,10 @@
+infrahouse\_toolkit.cli.ih\_elastic.cmd\_cluster.cmd\_allocation\_explain package
+=================================================================================
+
+Module contents
+---------------
+
+.. automodule:: infrahouse_toolkit.cli.ih_elastic.cmd_cluster.cmd_allocation_explain
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cluster.rst
+++ b/docs/infrahouse_toolkit.cli.ih_elastic.cmd_cluster.rst
@@ -1,0 +1,18 @@
+infrahouse\_toolkit.cli.ih\_elastic.cmd\_cluster package
+========================================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   infrahouse_toolkit.cli.ih_elastic.cmd_cluster.cmd_allocation_explain
+
+Module contents
+---------------
+
+.. automodule:: infrahouse_toolkit.cli.ih_elastic.cmd_cluster
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/infrahouse_toolkit.cli.ih_elastic.rst
+++ b/docs/infrahouse_toolkit.cli.ih_elastic.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    infrahouse_toolkit.cli.ih_elastic.cmd_cat
+   infrahouse_toolkit.cli.ih_elastic.cmd_cluster
    infrahouse_toolkit.cli.ih_elastic.cmd_cluster_health
    infrahouse_toolkit.cli.ih_elastic.cmd_passwd
    infrahouse_toolkit.cli.ih_elastic.cmd_snapshots

--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.30.0
+:Version: 2.31.0
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.30.0"
+__version__ = "2.31.0"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/cli/ih_elastic/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/__init__.py
@@ -16,13 +16,14 @@ from elasticsearch import Elasticsearch
 from requests.auth import HTTPBasicAuth
 
 from infrahouse_toolkit.cli.ih_elastic.cmd_cat import cmd_cat
+from infrahouse_toolkit.cli.ih_elastic.cmd_cluster import cmd_cluster
 from infrahouse_toolkit.cli.ih_elastic.cmd_cluster_health import cmd_cluster_health
 from infrahouse_toolkit.cli.ih_elastic.cmd_passwd import cmd_passwd
 from infrahouse_toolkit.cli.ih_elastic.cmd_snapshots import cmd_snapshots
 from infrahouse_toolkit.cli.lib import get_elastic_password
 from infrahouse_toolkit.logging import setup_logging
 
-LOG = getLogger()
+LOG = getLogger(__name__)
 
 
 @click.group(
@@ -98,6 +99,6 @@ def ih_elastic(ctx, **kwargs):  # pylint: disable=unused-argument
     }
 
 
-for cmd in [cmd_passwd, cmd_cluster_health, cmd_snapshots, cmd_cat]:
+for cmd in [cmd_passwd, cmd_cluster_health, cmd_snapshots, cmd_cat, cmd_cluster]:
     # noinspection PyTypeChecker
     ih_elastic.add_command(cmd)

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cat/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cat/__init__.py
@@ -5,15 +5,15 @@
 
     See ``ih-elastic cat --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import click
 
 from infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_repositories import cmd_repositories
+from infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_shards import cmd_shards
 from infrahouse_toolkit.cli.ih_elastic.cmd_cat.cmd_snapshots import cmd_snapshots
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.group(name="cat")
@@ -23,6 +23,6 @@ def cmd_cat():
     """
 
 
-for cmd in [cmd_repositories, cmd_snapshots]:
+for cmd in [cmd_repositories, cmd_snapshots, cmd_shards]:
     # noinspection PyTypeChecker
     cmd_cat.add_command(cmd)

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_repositories/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_repositories/__init__.py
@@ -5,13 +5,12 @@
 
     See ``ih-elastic cat repositories --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import click
 from elasticsearch.client import CatClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="repositories")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_shards/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_shards/__init__.py
@@ -1,0 +1,27 @@
+"""
+.. topic:: ``ih-elastic cat shards``
+
+    A ``ih-elastic cat shards`` subcommand.
+
+    See ``ih-elastic cat shards --help`` for more details.
+"""
+import json
+from logging import getLogger
+
+import click
+from elasticsearch.client import CatClient
+
+LOG = getLogger(__name__)
+
+
+@click.command(name="shards")
+@click.pass_context
+def cmd_shards(ctx):
+    """
+    Returns information about snapshot shards registered in the cluster.
+    """
+    client = CatClient(ctx.obj["es"])
+    if ctx.obj["format"] == "json":
+        print(json.dumps(client.shards(format=ctx.obj["format"], v=True).raw, indent=4))
+    else:
+        print(client.shards(format=ctx.obj["format"], v=True))

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_shards/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_shards/__init__.py
@@ -18,7 +18,7 @@ LOG = getLogger(__name__)
 @click.pass_context
 def cmd_shards(ctx):
     """
-    Returns information about snapshot shards registered in the cluster.
+    Provides a detailed view of shard allocation on nodes.
     """
     client = CatClient(ctx.obj["es"])
     if ctx.obj["format"] == "json":

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_snapshots/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_snapshots/__init__.py
@@ -5,13 +5,12 @@
 
     See ``ih-elastic cat snapshots --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import click
 from elasticsearch.client import CatClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="snapshots")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cluster/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cluster/__init__.py
@@ -1,0 +1,28 @@
+"""
+.. topic:: ``ih-elastic cat``
+
+    A ``ih-elastic cat`` subcommand.
+
+    See ``ih-elastic cat --help`` for more details.
+"""
+from logging import getLogger
+
+import click
+
+from infrahouse_toolkit.cli.ih_elastic.cmd_cluster.cmd_allocation_explain import (
+    cmd_allocation_explain,
+)
+
+LOG = getLogger(__name__)
+
+
+@click.group(name="cluster")
+def cmd_cluster():
+    """
+    Cluster level operations.
+    """
+
+
+for cmd in [cmd_allocation_explain]:
+    # noinspection PyTypeChecker
+    cmd_cluster.add_command(cmd)

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cluster/cmd_allocation_explain/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cluster/cmd_allocation_explain/__init__.py
@@ -1,0 +1,61 @@
+"""
+.. topic:: ``ih-elastic cat shards``
+
+    A ``ih-elastic cat shards`` subcommand.
+
+    See ``ih-elastic cat shards --help`` for more details.
+"""
+import json
+import sys
+from logging import getLogger
+
+import click
+from elasticsearch import BadRequestError
+from elasticsearch.client import ClusterClient
+
+LOG = getLogger(__name__)
+
+
+@click.command(name="allocation-explain")
+@click.option(
+    "--index",
+    help="Specifies the name of the index that you would like an explanation for."
+    " Run ih-elastic cat shards to get a list.",
+    default=None,
+    show_default=True,
+)
+@click.option(
+    "--shard",
+    help="Specifies the ID of the shard that you would like an explanation for."
+    " Run ih-elastic cat shards to get a list.",
+    default=None,
+    show_default=True,
+    type=click.INT,
+)
+@click.option(
+    "--primary/--replica",
+    help="If --primary, returns explanation for the primary shard for the given shard ID.",
+    default=None,
+    show_default=True,
+    is_flag=True,
+)
+@click.pass_context
+def cmd_allocation_explain(ctx, **kwargs):
+    """
+    Provides explanations for shard allocations in the cluster.
+    """
+    client = ClusterClient(ctx.obj["es"])
+    print(kwargs)
+    # 1/0
+    try:
+        ae_kwargs = {}
+        for arg in ["index", "shard"]:
+            if kwargs[arg]:
+                ae_kwargs[arg] = kwargs[arg]
+        if kwargs["primary"] is not None:
+            ae_kwargs["primary"] = kwargs["primary"]
+
+        LOG.info(json.dumps(client.allocation_explain(**ae_kwargs).body, indent=4))
+    except BadRequestError as err:
+        LOG.error(json.dumps(err.body, indent=4))
+        sys.exit(1)

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cluster/cmd_allocation_explain/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cluster/cmd_allocation_explain/__init__.py
@@ -45,8 +45,6 @@ def cmd_allocation_explain(ctx, **kwargs):
     Provides explanations for shard allocations in the cluster.
     """
     client = ClusterClient(ctx.obj["es"])
-    print(kwargs)
-    # 1/0
     try:
         ae_kwargs = {}
         for arg in ["index", "shard"]:

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cluster_health/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cluster_health/__init__.py
@@ -7,12 +7,12 @@
 """
 
 import json
-import logging
+from logging import getLogger
 
 import click
 from elasticsearch.client import ClusterClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="cluster-health")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_passwd/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_passwd/__init__.py
@@ -5,14 +5,13 @@
 
     See ``ih-elastic passwd --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import boto3
 import click
 from elasticsearch.client import SecurityClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="passwd")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/__init__.py
@@ -5,8 +5,7 @@
 
     See ``ih-elastic snapshots --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import click
 
@@ -20,7 +19,7 @@ from infrahouse_toolkit.cli.ih_elastic.cmd_snapshots.cmd_delete_repository impor
 from infrahouse_toolkit.cli.ih_elastic.cmd_snapshots.cmd_restore import cmd_restore
 from infrahouse_toolkit.cli.ih_elastic.cmd_snapshots.cmd_status import cmd_status
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.group(name="snapshots")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_create/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_create/__init__.py
@@ -7,8 +7,8 @@
 """
 
 import json
-import logging
 from datetime import datetime, timezone
+from logging import getLogger
 
 import click
 from elasticsearch import NotFoundError
@@ -16,7 +16,7 @@ from elasticsearch.client import ClusterClient, SnapshotClient
 
 from infrahouse_toolkit import DEFAULT_OPEN_ENCODING
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="create")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_create_repository/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_create_repository/__init__.py
@@ -5,13 +5,12 @@
 
     See ``ih-elastic snapshots create-repository --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import click
 from elasticsearch.client import SnapshotClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="create-repository")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_delete_repository/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_delete_repository/__init__.py
@@ -5,13 +5,12 @@
 
     See ``ih-elastic snapshots delete-repository --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import click
 from elasticsearch.client import SnapshotClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="delete-repository")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_restore/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_restore/__init__.py
@@ -5,13 +5,12 @@
 
     See ``ih-elastic snapshots restore --help`` for more details.
 """
-
-import logging
+from logging import getLogger
 
 import click
 from elasticsearch.client import SnapshotClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="restore")

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_status/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_snapshots/cmd_status/__init__.py
@@ -7,12 +7,12 @@
 """
 
 import json
-import logging
+from logging import getLogger
 
 import click
 from elasticsearch.client import SnapshotClient
 
-LOG = logging.getLogger()
+LOG = getLogger(__name__)
 
 
 @click.command(name="status")

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.30.0'
+build_version '2.31.0'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.30.0
+current_version = 2.31.0
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.30.0",
+    version="2.31.0",
     zip_safe=False,
 )


### PR DESCRIPTION
Inspired by
https://www.elastic.co/guide/en/elasticsearch/reference/current/red-yellow-cluster-status.html
`ih-elastic` gets two new subcommands to debug the red/yellow cluster
state.

* `ih-elastic cat shards` lists shards with their details.
* `ih-elastic cluster allocation-explain` explains successful and
unsuccessful allocations.

Both subcommands are supposred to run on an Elasticsearch node.

- New ih-elastic commands
- Bump version: 2.30.0 → 2.31.0
