### PR TITLE
Fix "Body is too long (maximum is 65536 characters)"

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.45.1
+:Version: 2.45.2
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.45.1"
+__version__ = "2.45.2"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/terraform/tests/github_pr/test_publish_comment.py
+++ b/infrahouse_toolkit/terraform/tests/github_pr/test_publish_comment.py
@@ -37,7 +37,7 @@ def test_publish_too_large_comment():
         GitHubPR, "pull_request", new_callable=mock.PropertyMock, return_value=mock_pull_request
     ), mock.patch.object(GitHubPR, "_publish_gist", return_value=mock_gist) as mock_publish_gist:
         gh_pr.publish_comment("foo comment")
-        mock_publish_gist.assert_called_once_with("pr-123-plan", "foo-bar-pr-123-plan.txt", "foo comment", False)
+        mock_publish_gist.assert_not_called()
         mock_pull_request.create_issue_comment.assert_has_calls(
-            [call("foo comment"), call("Comment was too big. It's published as a gist at gist url.")]
+            [call("foo comment"), call("Comment was too big. Check the CI workflow output.")]
         )

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.45.1'
+build_version '2.45.2'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.45.1
+current_version = 2.45.2
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.45.1",
+    version="2.45.2",
     zip_safe=False,
 )


### PR DESCRIPTION
- **Don't publish too large comment.**
- **Bump version: 2.45.1 → 2.45.2**
