### PR TITLE
Configure timeout when listing Elasticsearch snapshots

### DIFF
--- a/infrahouse_toolkit/__init__.py
+++ b/infrahouse_toolkit/__init__.py
@@ -2,13 +2,13 @@
 Top-level package for InfraHouse Toolkit.
 
 :Author: Oleksandr Kuzminskyi
-:Version: 2.47.0
+:Version: 2.47.1
 :Email: aleks@infrahouse.com
 """
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "2.47.0"
+__version__ = "2.47.1"
 
 DEFAULT_OPEN_ENCODING = "utf8"
 DEFAULT_ENCODING = DEFAULT_OPEN_ENCODING

--- a/infrahouse_toolkit/cli/ih_elastic/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/__init__.py
@@ -25,7 +25,7 @@ from infrahouse_toolkit.cli.ih_elastic.cmd_snapshots import cmd_snapshots
 from infrahouse_toolkit.cli.lib import get_elastic_password
 from infrahouse_toolkit.logging import setup_logging
 
-LOG = getLogger(__name__)
+LOG = getLogger()
 
 
 @click.group(
@@ -66,6 +66,9 @@ LOG = getLogger(__name__)
 )
 @click.option("--es-port", help="Elasticsearch port", default=9200, show_default=True)
 @click.option("--format", help="Output format", type=click.Choice(["text", "json", "cbor", "yaml", "smile"]))
+@click.option(
+    "--request-timeout", help="Timeout for HTTP requests in seconds.", default=10, show_default=True, type=click.INT
+)
 @click.version_option()
 @click.pass_context
 def ih_elastic(ctx, **kwargs):  # pylint: disable=unused-argument
@@ -97,7 +100,7 @@ def ih_elastic(ctx, **kwargs):  # pylint: disable=unused-argument
         "auth": HTTPBasicAuth(kwargs["username"], password),
         "username": kwargs["username"],
         "password": password,
-        "es": Elasticsearch(url, basic_auth=(kwargs["username"], password)),
+        "es": Elasticsearch(url, basic_auth=(kwargs["username"], password), request_timeout=kwargs["request_timeout"]),
         "format": kwargs["format"],
     }
 

--- a/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_snapshots/__init__.py
+++ b/infrahouse_toolkit/cli/ih_elastic/cmd_cat/cmd_snapshots/__init__.py
@@ -6,9 +6,11 @@
     See ``ih-elastic cat snapshots --help`` for more details.
 """
 
+import sys
 from logging import getLogger
 
 import click
+from elastic_transport import ConnectionTimeout
 from elasticsearch.client import CatClient
 
 LOG = getLogger(__name__)
@@ -20,5 +22,17 @@ def cmd_snapshots(ctx):
     """
     Returns all snapshots.
     """
-    client = CatClient(ctx.obj["es"])
-    LOG.info("\n%s", client.snapshots(repository="_all", format=ctx.obj["format"], v=True))
+    try:
+        client: CatClient = CatClient(ctx.obj["es"])
+        kwargs = {"repository": "_all", "format": ctx.obj["format"], "v": True, "request_timeout": 3600}
+        # Disabling unexpected-keyword-arg because in elasticsearch 8.12.0 package version pylint fails
+        # However, actual test proves `request_timeout` to be a valid argument.
+        # 8.15.0 fixes this problem however the package is backwards incompatible.
+        LOG.info(
+            "\n%s",
+            client.snapshots(**kwargs),  # pylint: disable=unexpected-keyword-arg
+        )
+    except ConnectionTimeout as err:
+        LOG.exception(err)
+        LOG.error("try to pass --request-timeout")
+        sys.exit(1)

--- a/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
+++ b/omnibus-infrahouse-toolkit/config/projects/infrahouse-toolkit.rb
@@ -12,7 +12,7 @@ homepage "https://infrahouse.com"
 # and /opt/infrahouse-toolkit on all other platforms
 install_dir "#{default_root}/#{name}"
 
-build_version '2.47.0'
+build_version '2.47.1'
 build_iteration 1
 
 override :openssl, version: '1.1.1t'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,10 @@ cached-property ~= 2.0
 certbot ~= 2.9
 certbot-dns-route53 ~= 2.9
 click ~= 8.1
-cryptography < 43.0.0 # Pinning until https://github.com/certbot/certbot/issues/9967 is fixed.
+cryptography ~= 44.0
 diskcache ~= 5.6
 ec2-metadata ~= 2.13
+elastic-transport ~= 8.12.0
 elasticsearch ~= 8.12.0
 infrahouse-core ~= 0.6
 pyhcl ~= 0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.47.0
+current_version = 2.47.1
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/infrahouse/infrahouse-toolkit",
-    version="2.47.0",
+    version="2.47.1",
     zip_safe=False,
 )


### PR DESCRIPTION
- **Set one hours timeout when listing snapshots**
- **Bump version: 2.47.0 → 2.47.1**
