### PR TITLE
Fix binascii.Error when user_data is sensitive in terraform plan (#209)

### DIFF
--- a/infrahouse_toolkit/terraform/status.py
+++ b/infrahouse_toolkit/terraform/status.py
@@ -2,6 +2,7 @@
 Module for :py:class:`TFStatus`, Terraform plan run status class.
 """
 
+import binascii
 import json
 import logging
 import re
@@ -208,7 +209,7 @@ class TFStatus:
                     ):
                         result_lines.append(diff_line)
                     result_lines.append("EOF userdata changes.")
-                except UnicodeDecodeError as err:
+                except (UnicodeDecodeError, binascii.Error) as err:
                     LOG.warning("Failed to decode userdata: %s", err)
             idx += 1
 


### PR DESCRIPTION
## Summary
- Catch `binascii.Error` alongside `UnicodeDecodeError` when decoding `user_data` in `_short_stdout`, so sensitive values like `(sensitive value)` don't crash `ih-plan publish`
- Added test that reproduces the exact crash from issue #209

Fixes #209

## Test plan
- [x] Added `test_comment_sensitive_user_data` that verifies the fix
- [x] Confirmed test fails without the fix (raises `binascii.Error`)
- [x] Confirmed test passes with the fix

