### PR TITLE
Add orchestrator MySQL user for topology discovery

### DIFF
--- a/infrahouse_toolkit/aws/mysql/instance.py
+++ b/infrahouse_toolkit/aws/mysql/instance.py
@@ -68,7 +68,7 @@ class MySQLInstance:
         """
         MySQL credentials from Secrets Manager (cached after first fetch).
 
-        :return: Credentials dictionary with keys ``replication``, ``backup``, ``monitor``.
+        :return: Credentials dictionary with keys ``replication``, ``backup``, ``monitor``, ``orchestrator``.
         :rtype: Dict[str, str]
         :raises MySQLBootstrapError: If credentials cannot be retrieved or are invalid.
         """
@@ -81,7 +81,7 @@ class MySQLInstance:
             except IHSecretNotFound as err:
                 raise MySQLBootstrapError(f"Failed to get credentials: {err}") from err
 
-            required_keys = ["replication", "backup", "monitor"]
+            required_keys = ["replication", "backup", "monitor", "orchestrator"]
             missing_keys = [key for key in required_keys if key not in value]
             if missing_keys:
                 raise MySQLBootstrapError(f"Missing required keys in credentials: {', '.join(missing_keys)}")
@@ -329,6 +329,12 @@ class MySQLInstance:
                 "host": vpc_cidr,
                 "password": credentials["monitor"],
                 "grants": "PROCESS, REPLICATION CLIENT, SELECT",
+            },
+            {
+                "username": "orchestrator",
+                "host": vpc_cidr,
+                "password": credentials["orchestrator"],
+                "grants": "SUPER, PROCESS, REPLICATION SLAVE, RELOAD, SELECT",
             },
         ]
 

--- a/infrahouse_toolkit/aws/tests/mysql/test_mysql_instance.py
+++ b/infrahouse_toolkit/aws/tests/mysql/test_mysql_instance.py
@@ -9,7 +9,7 @@ from infrahouse_core.aws.exceptions import IHSecretNotFound
 
 from infrahouse_toolkit.aws.mysql import MySQLBootstrapError, MySQLInstance
 
-MOCK_CREDENTIALS = {"replication": "rpass", "backup": "bpass", "monitor": "mpass"}
+MOCK_CREDENTIALS = {"replication": "rpass", "backup": "bpass", "monitor": "mpass", "orchestrator": "opass"}
 
 
 @pytest.fixture()
@@ -62,9 +62,9 @@ class TestCredentials:
     @patch("infrahouse_toolkit.aws.mysql.instance.Secret")
     def test_valid_credentials(self, mock_secret_cls: MagicMock, mysql_instance: MySQLInstance) -> None:
         """Returns credentials when secret is valid."""
-        mock_secret_cls.return_value.value = {"replication": "r", "backup": "b", "monitor": "m"}
+        mock_secret_cls.return_value.value = {"replication": "r", "backup": "b", "monitor": "m", "orchestrator": "o"}
         creds = mysql_instance.credentials
-        assert creds == {"replication": "r", "backup": "b", "monitor": "m"}
+        assert creds == {"replication": "r", "backup": "b", "monitor": "m", "orchestrator": "o"}
 
     @patch("infrahouse_toolkit.aws.mysql.instance.Secret")
     def test_secret_not_found(self, mock_secret_cls: MagicMock, mysql_instance: MySQLInstance) -> None:
@@ -90,7 +90,7 @@ class TestCredentials:
     @patch("infrahouse_toolkit.aws.mysql.instance.Secret")
     def test_cached(self, mock_secret_cls: MagicMock, mysql_instance: MySQLInstance) -> None:
         """Credentials are fetched only once and cached."""
-        mock_secret_cls.return_value.value = {"replication": "r", "backup": "b", "monitor": "m"}
+        mock_secret_cls.return_value.value = {"replication": "r", "backup": "b", "monitor": "m", "orchestrator": "o"}
         _ = mysql_instance.credentials
         _ = mysql_instance.credentials
         mock_secret_cls.assert_called_once()
@@ -366,15 +366,15 @@ class TestCreateMySQLUsers:
     def test_all_users_created(
         self, mock_create: MagicMock, mock_creds: MagicMock, mysql_instance: MySQLInstance
     ) -> None:
-        """Calls create_user_if_not_exists for all four users."""
+        """Calls create_user_if_not_exists for all five users."""
         mysql_instance.create_mysql_users()
-        assert mock_create.call_count == 4
+        assert mock_create.call_count == 5
 
     @patch.object(MySQLInstance, "credentials", new_callable=PropertyMock, return_value=MOCK_CREDENTIALS)
     @patch.object(MySQLInstance, "create_user_if_not_exists")
     def test_failure_raises(self, mock_create: MagicMock, mock_creds: MagicMock, mysql_instance: MySQLInstance) -> None:
         """Raises MySQLBootstrapError when any user creation fails."""
-        mock_create.side_effect = [None, MySQLBootstrapError("failed"), None, None]
+        mock_create.side_effect = [None, MySQLBootstrapError("failed"), None, None, None]
         with pytest.raises(MySQLBootstrapError):
             mysql_instance.create_mysql_users()
 


### PR DESCRIPTION
Create orchestrator user during bootstrap with SUPER, PROCESS,
REPLICATION SLAVE, RELOAD, and SELECT grants to support MySQL
Orchestrator's topology discovery and failover management.
