### PR TITLE
feat: add `ih-openvpn sync-google-users`

### DIFF
--- a/docs/infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users.rst
+++ b/docs/infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users.rst
@@ -1,0 +1,10 @@
+infrahouse\_toolkit.cli.ih\_openvpn.cmd\_sync\_google\_users package
+===================================================================
+
+Module contents
+---------------
+
+.. automodule:: infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/infrahouse_toolkit.cli.ih_openvpn.rst
+++ b/docs/infrahouse_toolkit.cli.ih_openvpn.rst
@@ -9,6 +9,7 @@ Subpackages
 
    infrahouse_toolkit.cli.ih_openvpn.cmd_list
    infrahouse_toolkit.cli.ih_openvpn.cmd_revoke
+   infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users
 
 Module contents
 ---------------

--- a/infrahouse_toolkit/cli/ih_openvpn/__init__.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/__init__.py
@@ -16,6 +16,10 @@ from infrahouse_core.logging import setup_logging
 from infrahouse_toolkit import DEFAULT_ENCODING
 from infrahouse_toolkit.cli.ih_openvpn.cmd_list import cmd_list_clients
 from infrahouse_toolkit.cli.ih_openvpn.cmd_revoke import cmd_revoke_client
+from infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users import (
+    cmd_sync_google_users,
+)
+from infrahouse_toolkit.cli.ih_openvpn.lib import DEFAULT_CONFIG_DIR
 
 LOG = getLogger()
 
@@ -36,6 +40,12 @@ LOG = getLogger()
     default="/usr/share/easy-rsa/easyrsa",
     show_default=True,
 )
+@click.option(
+    "--config-dir",
+    help="OpenVPN configuration directory, holding pki/, vars and ca_passphrase.",
+    default=DEFAULT_CONFIG_DIR,
+    show_default=True,
+)
 @click.pass_context
 def ih_openvpn(ctx, **kwargs):  # pylint: disable=unused-argument
     """
@@ -49,6 +59,7 @@ def ih_openvpn(ctx, **kwargs):  # pylint: disable=unused-argument
         LOG.debug("Running openvpn command: %s", out.decode(DEFAULT_ENCODING))
         ctx.obj = {
             "easyrsa_path": kwargs["easyrsa_path"],
+            "config_dir": kwargs["config_dir"],
         }
 
     except FileNotFoundError as err:
@@ -57,6 +68,6 @@ def ih_openvpn(ctx, **kwargs):  # pylint: disable=unused-argument
         sys.exit(1)
 
 
-for cmd in [cmd_list_clients, cmd_revoke_client]:
+for cmd in [cmd_list_clients, cmd_revoke_client, cmd_sync_google_users]:
     # noinspection PyTypeChecker
     ih_openvpn.add_command(cmd)

--- a/infrahouse_toolkit/cli/ih_openvpn/cmd_list/__init__.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/cmd_list/__init__.py
@@ -13,13 +13,14 @@ import click
 from tabulate import tabulate
 
 from infrahouse_toolkit import DEFAULT_OPEN_ENCODING
+from infrahouse_toolkit.cli.ih_openvpn.lib import index_path
 
 LOG = logging.getLogger()
 
 
 @click.command(name="list-clients")
 @click.pass_context
-def cmd_list_clients(ctx, *args, **kwargs):
+def cmd_list_clients(ctx: click.Context, *args, **kwargs):
     """
     List OpenVPN clients.
     """
@@ -28,7 +29,7 @@ def cmd_list_clients(ctx, *args, **kwargs):
     LOG.debug(ctx.args)
     header = ["Valid", "Created at", "Revoked at", "Serial", "State", "Certificate"]
     users = []
-    with open("/etc/openvpn/pki/index.txt", encoding=DEFAULT_OPEN_ENCODING) as fp:
+    with open(index_path(ctx.obj["config_dir"]), encoding=DEFAULT_OPEN_ENCODING) as fp:
         lines = fp.read().splitlines()
         for line in lines:
             cells = line.split("\t")

--- a/infrahouse_toolkit/cli/ih_openvpn/cmd_revoke/__init__.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/cmd_revoke/__init__.py
@@ -8,9 +8,11 @@
 
 import logging
 import sys
-from subprocess import CalledProcessError, check_call
+from subprocess import CalledProcessError
 
 import click
+
+from infrahouse_toolkit.cli.ih_openvpn.lib import revoke_client
 
 LOG = logging.getLogger()
 
@@ -18,7 +20,7 @@ LOG = logging.getLogger()
 @click.command(name="revoke-client")
 @click.argument("client")
 @click.pass_context
-def cmd_revoke_client(ctx, *args, **kwargs):
+def cmd_revoke_client(ctx: click.Context, *args, **kwargs):
     """
     Revoke client certificate from OpenVPN. Specify the client by email.
 
@@ -29,22 +31,16 @@ def cmd_revoke_client(ctx, *args, **kwargs):
     LOG.debug("args = %s", args)
     LOG.debug("kwargs = %s", kwargs)
     LOG.debug(ctx.obj)
-    revoke_cmd = [ctx.obj["easyrsa_path"], "--vars=/etc/openvpn/vars", "revoke", kwargs["client"]]
-    update_cmd = [ctx.obj["easyrsa_path"], "--vars=/etc/openvpn/vars", "gen-crl"]
     try:
-        for command in [revoke_cmd, update_cmd]:
-            check_call(
-                command,
-                env={
-                    "EASYRSA_PASSIN": "file:/etc/openvpn/ca_passphrase",
-                },
-            )
+        revoke_client(ctx.obj["easyrsa_path"], kwargs["client"], ctx.obj["config_dir"])
         LOG.info("VPN access for client %s is revoked.", kwargs["client"])
     except CalledProcessError as err:
         LOG.error(err)
+        update_cmd = [ctx.obj["easyrsa_path"], f"--vars={ctx.obj['config_dir']}/vars", "gen-crl"]
         LOG.info(
             "If you want to update the Certificate Revocation List, "
-            "run command `sudo EASYRSA_PASSIN=file:/etc/openvpn/ca_passphrase %s`",
+            "run command `sudo EASYRSA_PASSIN=file:%s/ca_passphrase %s`",
+            ctx.obj["config_dir"],
             " ".join(update_cmd),
         )
         sys.exit(1)

--- a/infrahouse_toolkit/cli/ih_openvpn/cmd_sync_google_users/__init__.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/cmd_sync_google_users/__init__.py
@@ -1,0 +1,276 @@
+"""
+.. topic:: ``ih-openvpn sync-google-users``
+
+    A ``ih-openvpn sync-google-users`` subcommand.
+
+    See ``ih-openvpn sync-google-users --help`` for more details.
+"""
+
+import logging
+import os
+import sys
+from subprocess import CalledProcessError
+
+import click
+
+from infrahouse_toolkit.cli.ih_openvpn.lib import (
+    index_path,
+    revoke_client,
+    valid_user_certificates,
+)
+
+LOG = logging.getLogger()
+
+#: ``EX_CONFIG`` from sysexits.h. Signals "the Google side is not configured
+#: yet" as distinct from "this is broken". The Puppet wrapper that drives this
+#: command on a cron treats 78 as *not ready* -- it logs and exits 0 -- so a
+#: fleet that has not yet had domain-wide delegation authorized stays quiet
+#: instead of mailing an operator daily. Any other non-zero status is reported
+#: as a genuine failure. Changing this value breaks that contract; see
+#: puppet-code ``modules/profile/templates/openvpn_server/google-user-sync.sh.erb``.
+EX_CONFIG = 78
+
+DIRECTORY_SCOPE = "https://www.googleapis.com/auth/admin.directory.user.readonly"
+CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+
+def _directory_client(service_account, admin_subject):
+    """
+    Build a Directory API client authenticated keylessly for ``admin_subject``.
+
+    Application Default Credentials resolve to the Workload Identity Federation
+    config that Terraform writes, which sources an AWS instance identity from
+    IMDS. That federated identity impersonates the directory-reader service
+    account, which in turn uses domain-wide delegation to act as
+    ``admin_subject``. No service-account key exists anywhere.
+
+    :param service_account: Email of the directory-reader service account.
+    :type service_account: str
+    :param admin_subject: Workspace admin the service account impersonates.
+    :type admin_subject: str
+    :return: A ready ``admin`` / ``directory_v1`` client.
+    :raise GoogleNotConfigured: if credentials cannot be resolved yet.
+    """
+    # Imported lazily so that the rest of ih-openvpn keeps working on hosts
+    # without the google libraries installed. The disable covers the whole block
+    # because black rewrites trailing per-line comments into the parentheses,
+    # where pylint no longer honours them.
+    # pylint: disable=import-outside-toplevel
+    import google.auth
+    from google.auth import impersonated_credentials
+    from google.auth.exceptions import DefaultCredentialsError
+    from googleapiclient.discovery import build
+
+    try:
+        source_credentials, _ = google.auth.default(scopes=[CLOUD_PLATFORM_SCOPE])
+    except DefaultCredentialsError as err:
+        # No usable Application Default Credentials: the Terraform-written
+        # credential config is missing or malformed, or IMDS is unreachable so
+        # the external_account source cannot produce an AWS identity. All are
+        # states that precede a finished deployment, not regressions.
+        raise GoogleNotConfigured(f"no usable application default credentials: {err}") from err
+
+    delegated = impersonated_credentials.Credentials(
+        source_credentials=source_credentials,
+        target_principal=service_account,
+        target_scopes=[DIRECTORY_SCOPE],
+        subject=admin_subject,
+    )
+    return build("admin", "directory_v1", credentials=delegated, cache_discovery=False)
+
+
+def get_active_directory_users(service_account, admin_subject):
+    """
+    List the primary email addresses of all non-suspended Google Workspace users.
+
+    :param service_account: Email of the directory-reader service account.
+    :type service_account: str
+    :param admin_subject: Workspace admin the service account impersonates.
+    :type admin_subject: str
+    :return: Primary email addresses of active users, lowercased.
+    :rtype: set(str)
+    :raise GoogleNotConfigured: if the Google side is not set up yet.
+    :raise HttpError: on a directory API error that is not a setup problem.
+    """
+    # pylint: disable=import-outside-toplevel
+    from google.auth.exceptions import RefreshError
+    from googleapiclient.errors import HttpError
+
+    directory = _directory_client(service_account, admin_subject)
+
+    users = set()
+    page_token = None
+    try:
+        while True:
+            # query="isSuspended=false" would push the filter server-side, but
+            # listing everyone and filtering here means a user missing from the
+            # response for any reason is never mistaken for a suspended one.
+            # googleapiclient builds resource methods dynamically from the
+            # discovery document, so .users() is invisible to static analysis.
+            response = (
+                directory.users()  # pylint: disable=no-member
+                .list(customer="my_customer", maxResults=500, projection="basic", pageToken=page_token)
+                .execute()
+            )
+            for user in response.get("users", []):
+                if not user.get("suspended", False):
+                    users.add(user["primaryEmail"].lower())
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+    except RefreshError as err:
+        # Domain-wide delegation has not been authorized for this service
+        # account's client id, so the token exchange is rejected outright.
+        raise GoogleNotConfigured(f"domain-wide delegation is not authorized: {err}") from err
+    except HttpError as err:
+        # 403 typically means delegation exists but the directory scope was not
+        # granted; 401 that the subject is not a real admin. Both are "not
+        # configured yet", not a regression, so they must not page anyone.
+        if err.resp.status in (401, 403):
+            raise GoogleNotConfigured(f"directory API rejected the request ({err.resp.status}): {err}") from err
+        raise
+
+    return users
+
+
+class GoogleNotConfigured(Exception):
+    """
+    The Google Workspace side of the integration is not set up yet.
+
+    Raised for conditions an operator is expected to hit *before* finishing
+    setup -- delegation not authorized, scope not granted, subject not an admin
+    -- and never for failures that appear after a working deployment. The
+    command maps it to :py:const:`EX_CONFIG`.
+    """
+
+
+@click.command(name="sync-google-users")
+@click.option(
+    "--service-account",
+    help="Directory-reader service account email. Defaults to $WIF_SA_EMAIL.",
+    default=lambda: os.environ.get("WIF_SA_EMAIL"),
+)
+@click.option(
+    "--admin-subject",
+    help="Workspace admin to impersonate. Defaults to $WIF_ADMIN_SUBJECT.",
+    default=lambda: os.environ.get("WIF_ADMIN_SUBJECT"),
+)
+@click.option(
+    "--dry-run",
+    help="Report what would be revoked without revoking anything.",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+@click.pass_context
+def cmd_sync_google_users(ctx: click.Context, **kwargs):
+    """
+    Revoke certificates of users deactivated in Google Workspace.
+
+    Reconciles the certificate index against the directory: every valid
+    user certificate whose owner is suspended, deleted or otherwise absent is
+    revoked. The server's own certificate is never a candidate.
+
+    CONFIGURATION comes from three environment variables, which on a
+    module-provisioned instance are written by Terraform to
+    /opt/openvpn-wif/wif.env (the file holds no secret -- the credential it
+    points at is a keyless federation config, not a key):
+
+    \b
+      GOOGLE_APPLICATION_CREDENTIALS  path to the WIF credential config
+      WIF_SA_EMAIL                    directory-reader service account
+      WIF_ADMIN_SUBJECT               Workspace admin to impersonate
+
+    So a by-hand run on an instance is source-then-invoke. --dry-run first is
+    the safe habit: it prints exactly who would be revoked and touches nothing.
+    Revoking is the default (the scheduled job invokes the command bare); there
+    is no separate "enforce" flag to remember.
+
+    \b
+      # load the config Terraform wrote
+      . /opt/openvpn-wif/wif.env
+      # preview -- lists deactivated users, revokes nothing
+      ih-openvpn sync-google-users --dry-run
+      # apply
+      ih-openvpn sync-google-users
+      # confirm -- the revoked cert now shows state R
+      ih-openvpn list-clients
+
+    Exit status is a contract with the Puppet cron wrapper: 0 on success, 78
+    when the Google side is not usable yet (most often domain-wide delegation
+    not authorized), any other code on a genuine failure. Point --config-dir at
+    a different OpenVPN installation, or override the service account / admin
+    subject, with the options below.
+    """
+    config_dir = ctx.obj["config_dir"]
+    service_account = kwargs["service_account"]
+    admin_subject = kwargs["admin_subject"]
+    dry_run = kwargs["dry_run"]
+
+    # Absent configuration is the pre-deployment state, not a usage error, so it
+    # exits EX_CONFIG rather than click's UsageError.
+    for name, value in (
+        ("--service-account/$WIF_SA_EMAIL", service_account),
+        ("--admin-subject/$WIF_ADMIN_SUBJECT", admin_subject),
+    ):
+        if not value:
+            LOG.info("%s is not set; the Google integration is not configured yet.", name)
+            sys.exit(EX_CONFIG)
+
+    certificate_index = index_path(config_dir)
+    try:
+        certificates = valid_user_certificates(certificate_index)
+    except FileNotFoundError:
+        LOG.info("%s does not exist; the PKI is not initialized yet.", certificate_index)
+        sys.exit(EX_CONFIG)
+
+    try:
+        active_users = get_active_directory_users(service_account, admin_subject)
+    except GoogleNotConfigured as err:
+        LOG.info("Google Workspace is not configured yet: %s", err)
+        sys.exit(EX_CONFIG)
+    except ImportError as err:
+        LOG.info("google libraries are not installed yet: %s", err)
+        sys.exit(EX_CONFIG)
+
+    # An empty directory response would make every certificate look orphaned.
+    # Treat it as a failed lookup rather than as "everyone was deactivated".
+    if not active_users:
+        LOG.error("The directory returned no active users; refusing to revoke every certificate.")
+        sys.exit(1)
+
+    stale = sorted(certificate for certificate in certificates if certificate.lower() not in active_users)
+    if not stale:
+        LOG.info(
+            "Checked %d certificate(s) against %d active user(s); nothing to revoke.",
+            len(certificates),
+            len(active_users),
+        )
+        return
+
+    if dry_run:
+        # Deliberately before any easy-rsa call, so --dry-run cannot touch the
+        # PKI no matter what happens below.
+        LOG.info(
+            "DRY RUN: would revoke %d certificate(s) of deactivated user(s): %s",
+            len(stale),
+            ", ".join(stale),
+        )
+        LOG.info("DRY RUN: nothing was revoked; re-run without --dry-run to apply.")
+        return
+
+    LOG.info("Revoking %d certificate(s) of deactivated user(s): %s", len(stale), ", ".join(stale))
+    failed = []
+    for common_name in stale:
+        try:
+            revoke_client(ctx.obj["easyrsa_path"], common_name, config_dir)
+            LOG.info("VPN access for client %s is revoked.", common_name)
+        except CalledProcessError as err:
+            # Keep going: one certificate easy-rsa cannot revoke should not
+            # leave the remaining deactivated users with working access.
+            LOG.error("Failed to revoke %s: %s", common_name, err)
+            failed.append(common_name)
+
+    if failed:
+        LOG.error("Failed to revoke %d certificate(s): %s", len(failed), ", ".join(failed))
+        sys.exit(1)

--- a/infrahouse_toolkit/cli/ih_openvpn/lib.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/lib.py
@@ -1,0 +1,176 @@
+"""
+.. topic:: ``infrahouse_toolkit.cli.ih_openvpn.lib``
+
+    Helpers shared by the ``ih-openvpn`` subcommands: parsing the easy-rsa
+    certificate index and revoking a client certificate.
+"""
+
+import logging
+import os
+from collections import namedtuple
+from subprocess import check_call
+
+from infrahouse_toolkit import DEFAULT_OPEN_ENCODING
+
+LOG = logging.getLogger()
+
+#: Fallback OpenVPN configuration directory. Defined once and used in exactly
+#: one place -- as the default of the ``ih-openvpn --config-dir`` option. Every
+#: subcommand and helper takes the directory from ``ctx.obj["config_dir"]``
+#: instead of reaching for this constant, so pointing the group at another
+#: directory moves all of them together.
+DEFAULT_CONFIG_DIR = "/etc/openvpn"
+
+
+def index_path(config_dir):
+    """
+    Path of the easy-rsa certificate index inside a configuration directory.
+
+    :param config_dir: OpenVPN configuration directory.
+    :type config_dir: str
+    :return: Path to ``pki/index.txt``.
+    :rtype: str
+    """
+    return os.path.join(config_dir, "pki", "index.txt")
+
+
+#: Status flag easy-rsa writes in column 0 of ``index.txt`` for a live
+#: certificate. ``R`` means revoked and ``E`` expired.
+STATUS_VALID = "V"
+
+#: One row of the easy-rsa ``index.txt``.
+IndexEntry = namedtuple("IndexEntry", ["status", "serial", "subject", "common_name"])
+
+
+def parse_index(path):
+    """
+    Parse an easy-rsa ``index.txt`` into :py:class:`IndexEntry` records.
+
+    The file is tab separated, one certificate per line::
+
+        V<TAB>expiry<TAB>revoked<TAB>serial<TAB>filename<TAB>subject-dn
+
+    Malformed lines are skipped with a warning rather than aborting: the index
+    is shared state on EFS, and one unreadable row should not stop the rest of
+    the certificates from being reconciled.
+
+    :param path: Path to ``index.txt``, e.g. from :py:func:`index_path`.
+    :type path: str
+    :return: Parsed entries, in file order.
+    :rtype: list(IndexEntry)
+    """
+    entries = []
+    with open(path, encoding=DEFAULT_OPEN_ENCODING) as file_descriptor:
+        for line_number, line in enumerate(file_descriptor.read().splitlines(), start=1):
+            if not line.strip():
+                continue
+            cells = line.split("\t")
+            if len(cells) < 6:
+                LOG.warning("Skipping malformed %s line %d: %r", path, line_number, line)
+                continue
+            entries.append(
+                IndexEntry(
+                    status=cells[0],
+                    serial=cells[3],
+                    subject=cells[5],
+                    common_name=extract_common_name(cells[5]),
+                )
+            )
+    return entries
+
+
+def extract_common_name(subject):
+    """
+    Pull the CN out of an OpenSSL subject DN.
+
+    The DN carries the full set of easy-rsa request fields, e.g.
+    ``/C=US/ST=California/O=InfraHouse Inc./CN=alice@infrahouse.com``, so the CN
+    cannot be assumed to sit at any fixed position.
+
+    :param subject: Subject DN as written in ``index.txt``.
+    :type subject: str
+    :return: The common name, or ``None`` when the DN carries no CN component.
+    :rtype: str
+    """
+    for component in subject.split("/"):
+        if component.startswith("CN="):
+            return component[len("CN=") :]
+    return None
+
+
+def is_user_certificate(common_name):
+    """
+    Whether a common name identifies a directory user rather than infrastructure.
+
+    This is a safety boundary, not a cosmetic filter. The PKI also contains the
+    OpenVPN server's own certificate (``CN=server``), which is valid and will
+    never appear in the Google directory. A reconciliation that treated every
+    valid certificate as a candidate would therefore compute the server
+    certificate as "belonging to no active user" and revoke it, taking the whole
+    VPN down -- and it would do so on the first run of a fresh deployment, when
+    no user certificates exist yet to dilute the diff.
+
+    User certificates are minted by the portal with ``EASYRSA_REQ_CN`` set to the
+    authenticated Google address, so every genuine user CN is an email address.
+    Requiring an ``@`` excludes ``server`` and any other infrastructure
+    certificate without needing to enumerate them.
+
+    :param common_name: Common name from a certificate subject.
+    :type common_name: str
+    :return: True when the CN looks like a directory user's email address.
+    :rtype: bool
+    """
+    return bool(common_name) and "@" in common_name
+
+
+def valid_user_certificates(path):
+    """
+    Common names of live, user-owned certificates -- the revocation candidates.
+
+    Filtered to valid (non-revoked, non-expired) certificates whose CN looks like
+    a directory user, so infrastructure certificates can never enter the diff.
+    See :py:func:`is_user_certificate`.
+
+    :param path: Path to ``index.txt``, e.g. from :py:func:`index_path`.
+    :type path: str
+    :return: Common names of live user certificates.
+    :rtype: set(str)
+    """
+    return {
+        entry.common_name
+        for entry in parse_index(path)
+        if entry.status == STATUS_VALID and is_user_certificate(entry.common_name)
+    }
+
+
+def revoke_client(easyrsa_path, client, config_dir):
+    """
+    Revoke a client certificate and regenerate the CRL.
+
+    OpenVPN re-reads the CRL on every new connection, so the revocation takes
+    effect without restarting the service.
+
+    ``config_dir`` is required rather than defaulted: every caller already holds
+    the value from the ``ih-openvpn --config-dir`` option, and a default here
+    would let a caller silently operate on ``/etc/openvpn`` while the operator
+    pointed the group elsewhere.
+
+    :param easyrsa_path: Path to the ``easyrsa`` executable.
+    :type easyrsa_path: str
+    :param client: Certificate common name, i.e. the user's email address.
+    :type client: str
+    :param config_dir: OpenVPN configuration directory holding ``vars`` and
+        ``ca_passphrase``.
+    :type config_dir: str
+    :raise CalledProcessError: if easy-rsa fails; the CRL may then be stale.
+        The caller decides how to surface that.
+    """
+    revoke_cmd = [easyrsa_path, f"--vars={config_dir}/vars", "revoke", client]
+    update_cmd = [easyrsa_path, f"--vars={config_dir}/vars", "gen-crl"]
+    for command in [revoke_cmd, update_cmd]:
+        check_call(
+            command,
+            env={
+                "EASYRSA_PASSIN": f"file:{config_dir}/ca_passphrase",
+            },
+        )

--- a/infrahouse_toolkit/cli/ih_openvpn/tests/test_lib.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/tests/test_lib.py
@@ -1,0 +1,111 @@
+"""Unit tests for :py:mod:`infrahouse_toolkit.cli.ih_openvpn.lib`."""
+
+import pytest
+
+from infrahouse_toolkit.cli.ih_openvpn.lib import (
+    extract_common_name,
+    is_user_certificate,
+    parse_index,
+    valid_user_certificates,
+)
+
+SERVER_DN = (
+    "/C=US/ST=California/L=San Francisco/O=InfraHouse Inc."
+    "/OU=Security Organization/CN=server/emailAddress=security@infrahouse.com"
+)
+USER_DN = "/C=US/ST=California/O=InfraHouse Inc./CN=alice@infrahouse.com"
+
+
+def write_index(tmp_path, rows):
+    """Write an easy-rsa style index.txt and return its path."""
+    index = tmp_path / "index.txt"
+    index.write_text("".join(rows), encoding="utf-8")
+    return str(index)
+
+
+def valid_row(subject, serial="01"):
+    """A tab-separated index.txt row for a live certificate."""
+    return f"V\t300101000000Z\t\t{serial}\tunknown\t{subject}\n"
+
+
+def revoked_row(subject, serial="02"):
+    """A tab-separated index.txt row for a revoked certificate."""
+    return f"R\t300101000000Z\t250101000000Z\t{serial}\tunknown\t{subject}\n"
+
+
+@pytest.mark.parametrize(
+    "subject, expected",
+    [
+        (SERVER_DN, "server"),
+        (USER_DN, "alice@infrahouse.com"),
+        ("/CN=bob@infrahouse.com", "bob@infrahouse.com"),
+        ("/C=US/O=NoCommonName", None),
+        ("", None),
+    ],
+)
+def test_extract_common_name(subject, expected):
+    """CN is found wherever it sits in the DN, and absence is reported as None."""
+    assert extract_common_name(subject) == expected
+
+
+@pytest.mark.parametrize(
+    "common_name, expected",
+    [
+        ("alice@infrahouse.com", True),
+        ("server", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_user_certificate(common_name, expected):
+    """Only email-shaped common names count as directory users."""
+    assert is_user_certificate(common_name) is expected
+
+
+def test_parse_index_reads_all_rows(tmp_path):
+    """Every well-formed row is parsed, with status and CN extracted."""
+    index = write_index(tmp_path, [valid_row(SERVER_DN), valid_row(USER_DN, "02")])
+    entries = parse_index(index)
+    assert [(entry.status, entry.common_name) for entry in entries] == [
+        ("V", "server"),
+        ("V", "alice@infrahouse.com"),
+    ]
+
+
+def test_parse_index_skips_malformed_rows(tmp_path):
+    """A truncated row is skipped rather than aborting the whole reconciliation."""
+    index = write_index(tmp_path, [valid_row(USER_DN), "garbage\n", "\n"])
+    assert [entry.common_name for entry in parse_index(index)] == ["alice@infrahouse.com"]
+
+
+def test_valid_user_certificates_excludes_server(tmp_path):
+    """
+    The server's own certificate is never a revocation candidate.
+
+    This is the guard against the catastrophic case: on a fresh deployment the
+    only valid certificate is CN=server, so a reconciliation that considered it
+    would compute it as belonging to no active user and revoke it, taking down
+    the VPN for everyone.
+    """
+    index = write_index(tmp_path, [valid_row(SERVER_DN)])
+    assert valid_user_certificates(index) == set()
+
+
+def test_valid_user_certificates_excludes_revoked(tmp_path):
+    """Already-revoked certificates are not candidates again."""
+    index = write_index(tmp_path, [valid_row(USER_DN), revoked_row("/CN=bob@infrahouse.com")])
+    assert valid_user_certificates(index) == {"alice@infrahouse.com"}
+
+
+def test_valid_user_certificates_mixed(tmp_path):
+    """A realistic index yields only the live user certificates."""
+    index = write_index(
+        tmp_path,
+        [
+            valid_row(SERVER_DN, "01"),
+            valid_row(USER_DN, "02"),
+            valid_row("/CN=bob@infrahouse.com", "03"),
+            revoked_row("/CN=carol@infrahouse.com", "04"),
+        ],
+    )
+    assert valid_user_certificates(index) == {"alice@infrahouse.com", "bob@infrahouse.com"}

--- a/infrahouse_toolkit/cli/ih_openvpn/tests/test_sync_google_users.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/tests/test_sync_google_users.py
@@ -1,0 +1,224 @@
+"""
+Unit tests for :py:mod:`infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users`.
+
+The exit-status contract is the point of this file. The Puppet wrapper that runs
+the command on a cron treats 78 (EX_CONFIG) as "not configured yet" -- it logs
+and exits 0 -- and anything else non-zero as a real failure worth mailing an
+operator about. If a not-yet-configured condition were to leak out as exit 1,
+every OpenVPN node in the fleet would mail root daily until someone finished the
+Google setup. These tests pin that boundary.
+"""
+
+import importlib
+from subprocess import CalledProcessError
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users import (
+    EX_CONFIG,
+    GoogleNotConfigured,
+    cmd_sync_google_users,
+    get_active_directory_users,
+)
+
+# The package and the Click command share the name cmd_sync_google_users, so
+# ih_openvpn.cmd_sync_google_users resolves to the command, not the module --
+# which makes a dotted-string mock target (or `import ... as`) land on the
+# command on some import orders (passed 3.11-3.14, failed 3.10). import_module
+# returns the real module object from sys.modules, so patch.object is stable.
+sync_module = importlib.import_module("infrahouse_toolkit.cli.ih_openvpn.cmd_sync_google_users")
+
+SERVER_DN = "/C=US/O=InfraHouse Inc./CN=server"
+
+
+@pytest.fixture(name="config_dir")
+def _config_dir(tmp_path):
+    """An OpenVPN config directory with a PKI holding a server and two user certificates."""
+    pki = tmp_path / "pki"
+    pki.mkdir()
+    (pki / "index.txt").write_text(
+        f"V\t300101000000Z\t\t01\tunknown\t{SERVER_DN}\n"
+        "V\t300101000000Z\t\t02\tunknown\t/CN=alice@infrahouse.com\n"
+        "V\t300101000000Z\t\t03\tunknown\t/CN=bob@infrahouse.com\n",
+        encoding="utf-8",
+    )
+    return str(tmp_path)
+
+
+def run(config_dir, extra_args=None, **kwargs):
+    """Invoke the command with the context the ih-openvpn group would normally supply."""
+    return CliRunner().invoke(
+        cmd_sync_google_users,
+        [
+            "--service-account",
+            "sa@example.iam.gserviceaccount.com",
+            "--admin-subject",
+            "admin@infrahouse.com",
+        ]
+        + (extra_args or []),
+        obj={"easyrsa_path": "/usr/share/easy-rsa/easyrsa", "config_dir": config_dir},
+        **kwargs,
+    )
+
+
+def test_dry_run_revokes_nothing(config_dir):
+    """
+    --dry-run reports the same set but never touches the PKI.
+
+    bob is absent from the directory, so without the flag this exact invocation
+    revokes bob's certificate (see test_revokes_only_deactivated_users).
+    """
+    with mock.patch.object(sync_module, "get_active_directory_users", return_value={"alice@infrahouse.com"}):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir, ["--dry-run"])
+    assert result.exit_code == 0
+    revoke.assert_not_called()
+
+
+def test_revoking_is_the_default(config_dir):
+    """
+    Omitting --dry-run revokes.
+
+    Pins the default the scheduled job depends on: the Puppet wrapper invokes
+    the command bare, and must not silently become a no-op.
+    """
+    with mock.patch.object(sync_module, "get_active_directory_users", return_value={"alice@infrahouse.com"}):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir)
+    assert result.exit_code == 0
+    revoke.assert_called_once()
+
+
+def test_exits_ex_config_when_delegation_not_authorized(config_dir):
+    """
+    Unauthorized domain-wide delegation must exit 78, not 1.
+
+    This is the case the operator hits between deploying the Terraform and
+    authorizing the client id in the Workspace admin console.
+    """
+    with mock.patch.object(
+        sync_module, "get_active_directory_users", side_effect=GoogleNotConfigured("not authorized")
+    ):
+        result = run(config_dir)
+    assert result.exit_code == EX_CONFIG
+
+
+def test_exits_ex_config_when_credentials_unusable(config_dir):
+    """
+    Unresolvable Application Default Credentials must exit 78, not 1.
+
+    Hit when the Terraform-written credential config is missing or malformed, or
+    when IMDS cannot be reached to source the AWS identity. Regression test: this
+    previously escaped as an uncaught DefaultCredentialsError traceback, which
+    the wrapper would have reported as a real failure and mailed daily.
+    """
+    with mock.patch.object(
+        sync_module,
+        "get_active_directory_users",
+        side_effect=GoogleNotConfigured("no usable application default credentials"),
+    ):
+        result = run(config_dir)
+    assert result.exit_code == EX_CONFIG
+
+
+def test_default_credentials_error_becomes_not_configured():
+    """
+    The real google-auth exception type is translated, not just its message.
+
+    Exercises get_active_directory_users directly with google.auth.default
+    patched, so the translation is pinned against the actual library error
+    rather than a stand-in the test itself invented.
+    """
+    google_auth = pytest.importorskip("google.auth")
+    from google.auth.exceptions import (  # pylint: disable=import-outside-toplevel
+        DefaultCredentialsError,
+    )
+
+    with mock.patch.object(google_auth, "default", side_effect=DefaultCredentialsError("bad config")):
+        with pytest.raises(GoogleNotConfigured):
+            get_active_directory_users("sa@example.iam.gserviceaccount.com", "admin@infrahouse.com")
+
+
+def test_exits_ex_config_when_google_libraries_missing(config_dir):
+    """A host without the google libraries is un-provisioned, not broken."""
+    with mock.patch.object(sync_module, "get_active_directory_users", side_effect=ImportError("no google.auth")):
+        result = run(config_dir)
+    assert result.exit_code == EX_CONFIG
+
+
+def test_exits_ex_config_without_service_account(config_dir):
+    """Missing configuration is the pre-deployment state, not a usage error."""
+    result = CliRunner().invoke(
+        cmd_sync_google_users,
+        ["--admin-subject", "admin@infrahouse.com"],
+        obj={"easyrsa_path": "/usr/share/easy-rsa/easyrsa", "config_dir": config_dir},
+    )
+    assert result.exit_code == EX_CONFIG
+
+
+def test_exits_ex_config_when_pki_absent(tmp_path):
+    """An instance whose PKI has not been generated yet is not ready."""
+    with mock.patch.object(sync_module, "get_active_directory_users", return_value={"alice@infrahouse.com"}):
+        result = run(str(tmp_path))
+    assert result.exit_code == EX_CONFIG
+
+
+def test_revokes_only_deactivated_users(config_dir):
+    """bob is absent from the directory, so only bob's certificate is revoked."""
+    with mock.patch.object(sync_module, "get_active_directory_users", return_value={"alice@infrahouse.com"}):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir)
+    assert result.exit_code == 0
+    revoke.assert_called_once_with("/usr/share/easy-rsa/easyrsa", "bob@infrahouse.com", config_dir)
+
+
+def test_never_revokes_the_server_certificate(config_dir):
+    """
+    Even when the directory knows nobody, the server certificate is untouchable.
+
+    An empty active-user set is refused outright, and CN=server would be filtered
+    out regardless -- two independent guards against killing the VPN.
+    """
+    with mock.patch.object(sync_module, "get_active_directory_users", return_value=set()):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir)
+    assert result.exit_code == 1
+    revoke.assert_not_called()
+
+
+def test_nothing_to_do_when_all_users_active(config_dir):
+    """A fully reconciled fleet revokes nothing and succeeds."""
+    with mock.patch.object(
+        sync_module,
+        "get_active_directory_users",
+        return_value={"alice@infrahouse.com", "bob@infrahouse.com"},
+    ):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir)
+    assert result.exit_code == 0
+    revoke.assert_not_called()
+
+
+def test_case_insensitive_match(config_dir):
+    """Directory addresses differing only in case are still the same user."""
+    with mock.patch.object(
+        sync_module,
+        "get_active_directory_users",
+        return_value={"alice@infrahouse.com", "BOB@infrahouse.com".lower()},
+    ):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir)
+    assert result.exit_code == 0
+    revoke.assert_not_called()
+
+
+def test_continues_after_a_failed_revocation(config_dir):
+    """One un-revokable certificate must not leave the others with working access."""
+    with mock.patch.object(sync_module, "get_active_directory_users", return_value=set(["carol@infrahouse.com"])):
+        with mock.patch.object(sync_module, "revoke_client", side_effect=CalledProcessError(1, "easyrsa")) as revoke:
+            result = run(config_dir)
+    # Both alice and bob are stale here; both were attempted despite the failure.
+    assert revoke.call_count == 2
+    assert result.exit_code == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ ec2-metadata ~= 2.13
 elastic-transport ~= 8.12.0
 elasticsearch ~= 8.12.0
 GitPython ~= 3.1, >= 3.1.30
+google-api-python-client ~= 2.0
+google-auth ~= 2.0
 idna >= 3.15
 infrahouse-core ~= 0.23, >= 0.23.6
 PyGithub ~= 2.4


### PR DESCRIPTION
## What

Revoke OpenVPN certificates of users deactivated in Google Workspace. A suspended or deleted user can no longer mint a certificate — the portal blocks their login — but any `.ovpn` they already hold keeps working until the CA revokes it. This reconciles the PKI index against the directory and revokes the gap.

Certificate CNs are Google email addresses (the portal signs requests with `EASYRSA_REQ_CN` set to the authenticated user), so the diff is: valid user certificates whose CN is no longer an active Workspace user.

## Keyless auth (no service-account key)

Application Default Credentials resolve to a Workload Identity Federation config that sources the instance's **AWS identity from IMDS**; that identity impersonates a directory-reader service account which, via domain-wide delegation, reads the directory as a Workspace admin. **No service-account key exists anywhere** — the config file it reads is not a secret. Inputs come from the environment (`GOOGLE_APPLICATION_CREDENTIALS`, `WIF_SA_EMAIL`, `WIF_ADMIN_SUBJECT`), written by `terraform-aws-openvpn` to `/opt/openvpn-wif/wif.env`.

## Safety: the server certificate is never a candidate

On a fresh deployment `CN=server` is the *only* valid certificate, so a naive valid-minus-active diff would revoke it and take the VPN down before anyone enrols. Two independent guards: user CNs must contain `@` (`server` has none), and an empty directory response is refused rather than treated as "everyone was deactivated".

## Interface

```
. /opt/openvpn-wif/wif.env
ih-openvpn sync-google-users --dry-run   # preview, touches nothing
ih-openvpn sync-google-users             # apply (revoking is the default)
ih-openvpn list-clients                  # confirm: revoked cert shows state R
```

Exit status is a contract with the Puppet cron wrapper: `0` success, `78` (EX_CONFIG) when the Google side is not usable yet (delegation unauthorized, credentials unresolvable, libraries absent), any other code a genuine failure. The wrapper treats 78 as "not configured yet" and stays quiet; everything else it surfaces. The full runbook and env vars are in `sync-google-users --help`.

## Refactor

Shared index-parsing and revoke logic factored into `lib.py`; `cmd_revoke` and `cmd_list` moved onto it. `--config-dir` is now a **group-level** option, so all three subcommands operate on the same OpenVPN installation (previously `cmd_list` hardcoded `/etc/openvpn`).

## Dependencies

Adds `google-auth` and `google-api-python-client`. Both are imported **lazily** so the rest of `ih-openvpn` keeps working on hosts without them (the distro `python3-google-auth` is 1.5.x and too old for WIF regardless).

## Testing

- 27 unit tests covering the exit-code contract (each not-configured condition → 78), the server-certificate guard, dry-run vs. enforce, case-insensitive matching, and partial-failure handling. `pylint` 10.00/10, `black`/`isort` clean, full suite 299 passed.
- **Verified end to end on a live instance**: `--dry-run` named a deactivated user (`sergey@tinyfish.io`), the apply revoked exactly that certificate and regenerated the CRL, and `list-clients` independently confirms it as state `R`. The keyless AWS → GCP → domain-wide-delegation chain read two separate real Workspaces.

## Note

No version bump in this commit, following the repo convention of a separate dedicated bump. This is a `feat`, so a minor bump when released. The Puppet cron wrapper that drives this on a schedule is puppet-code #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)