### PR TITLE
fix: tidy ih-openvpn sync-google-users after #251

### DIFF
--- a/infrahouse_toolkit/cli/ih_openvpn/cmd_sync_google_users/__init__.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/cmd_sync_google_users/__init__.py
@@ -13,6 +13,7 @@ from subprocess import CalledProcessError
 
 import click
 
+from infrahouse_toolkit.cli.ih_openvpn.exceptions import GoogleNotConfigured
 from infrahouse_toolkit.cli.ih_openvpn.lib import (
     index_path,
     revoke_client,
@@ -34,6 +35,7 @@ DIRECTORY_SCOPE = "https://www.googleapis.com/auth/admin.directory.user.readonly
 CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
 
+# noinspection PyPackageRequirements,PyUnresolvedReferences
 def _directory_client(service_account, admin_subject):
     """
     Build a Directory API client authenticated keylessly for ``admin_subject``.
@@ -51,8 +53,11 @@ def _directory_client(service_account, admin_subject):
     :return: A ready ``admin`` / ``directory_v1`` client.
     :raise GoogleNotConfigured: if credentials cannot be resolved yet.
     """
-    # Imported lazily so that the rest of ih-openvpn keeps working on hosts
-    # without the google libraries installed. The disable covers the whole block
+    # Imported here rather than at module top so the other ih-openvpn
+    # subcommands (list-clients, revoke-client) do not pay to load the google
+    # stack they never use. The libraries are declared dependencies, so a failed
+    # import is a broken install and is left to propagate loudly -- not caught
+    # and disguised as "not configured yet". The disable covers the whole block
     # because black rewrites trailing per-line comments into the parentheses,
     # where pylint no longer honours them.
     # pylint: disable=import-outside-toplevel
@@ -79,6 +84,7 @@ def _directory_client(service_account, admin_subject):
     return build("admin", "directory_v1", credentials=delegated, cache_discovery=False)
 
 
+# noinspection PyPackageRequirements,PyUnresolvedReferences
 def get_active_directory_users(service_account, admin_subject):
     """
     List the primary email addresses of all non-suspended Google Workspace users.
@@ -131,17 +137,6 @@ def get_active_directory_users(service_account, admin_subject):
         raise
 
     return users
-
-
-class GoogleNotConfigured(Exception):
-    """
-    The Google Workspace side of the integration is not set up yet.
-
-    Raised for conditions an operator is expected to hit *before* finishing
-    setup -- delegation not authorized, scope not granted, subject not an admin
-    -- and never for failures that appear after a working deployment. The
-    command maps it to :py:const:`EX_CONFIG`.
-    """
 
 
 @click.command(name="sync-google-users")
@@ -228,9 +223,6 @@ def cmd_sync_google_users(ctx: click.Context, **kwargs):
         active_users = get_active_directory_users(service_account, admin_subject)
     except GoogleNotConfigured as err:
         LOG.info("Google Workspace is not configured yet: %s", err)
-        sys.exit(EX_CONFIG)
-    except ImportError as err:
-        LOG.info("google libraries are not installed yet: %s", err)
         sys.exit(EX_CONFIG)
 
     # An empty directory response would make every certificate look orphaned.

--- a/infrahouse_toolkit/cli/ih_openvpn/exceptions.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/exceptions.py
@@ -1,0 +1,20 @@
+"""
+cli module exceptions.
+"""
+
+from infrahouse_toolkit.cli.exceptions import IHCLIError
+
+
+class IHOpenVPNError(IHCLIError):
+    """ih-openvpn errors."""
+
+
+class GoogleNotConfigured(IHOpenVPNError):
+    """
+    The Google Workspace side of the integration is not set up yet.
+
+    Raised for conditions an operator is expected to hit *before* finishing
+    setup -- delegation not authorized, scope not granted, subject not an admin
+    -- and never for failures that appear after a working deployment. The
+    command maps it to the ``EX_CONFIG`` (78) exit status.
+    """

--- a/infrahouse_toolkit/cli/ih_openvpn/tests/test_sync_google_users.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/tests/test_sync_google_users.py
@@ -141,13 +141,6 @@ def test_default_credentials_error_becomes_not_configured():
             get_active_directory_users("sa@example.iam.gserviceaccount.com", "admin@infrahouse.com")
 
 
-def test_exits_ex_config_when_google_libraries_missing(config_dir):
-    """A host without the google libraries is un-provisioned, not broken."""
-    with mock.patch.object(sync_module, "get_active_directory_users", side_effect=ImportError("no google.auth")):
-        result = run(config_dir)
-    assert result.exit_code == EX_CONFIG
-
-
 def test_exits_ex_config_without_service_account(config_dir):
     """Missing configuration is the pre-deployment state, not a usage error."""
     result = CliRunner().invoke(


### PR DESCRIPTION
Follow-up to the merged #251. Two corrections from review that landed after the merge.

## 1. `GoogleNotConfigured` joins the toolkit exception hierarchy

It was a bare `Exception`. Now it lives in a new `infrahouse_toolkit/cli/ih_openvpn/exceptions.py` and subclasses `IHOpenVPNError(IHCLIError)`, matching the convention every other group follows (`IHGithubError → IHVariableNotFound`, etc.):

```
GoogleNotConfigured → IHOpenVPNError → IHCLIError → IHException → Exception
```

## 2. Drop the `except ImportError → EX_CONFIG` branch

`google-auth` and `google-api-python-client` are declared dependencies, so pip installs them with the toolkit — a failed import is a **broken install**, not a "not configured yet" state.

Mapping `ImportError` to `EX_CONFIG` (78) made the Puppet cron wrapper treat a broken install as "not ready" and stay silent, hiding a real breakage indefinitely — the same failure mode the exit-code contract exists to prevent. A missing library now propagates loudly (non-78 → the wrapper mails it).

The lazy import stays, but only for its real reason — sparing `list-clients`/`revoke-client` from loading the google stack they never use — and the comment is corrected to say that instead of the old "hosts without the google libraries installed" justification. The test that pinned the old swallow-`ImportError` behavior is removed.

## Testing

`pylint` 10.00/10, `black`/`isort` clean, 298 passed / 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)