### PR TITLE
feat: multi-Workspace cert revocation; --version on four CLIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,5 @@ ENV/
 .vscode/
 .idea/
 /.claude/*.local.json
+.claude/plans/*.local.md
 nul

--- a/infrahouse_toolkit/cli/ih_certbot/__init__.py
+++ b/infrahouse_toolkit/cli/ih_certbot/__init__.py
@@ -40,6 +40,7 @@ LOG = getLogger()
     default="/opt/infrahouse-toolkit/embedded/bin/certbot",
     show_default=True,
 )
+@click.version_option()
 @click.pass_context
 def ih_certbot(ctx, *args, **kwargs):  # pylint: disable=unused-argument
     """

--- a/infrahouse_toolkit/cli/ih_openvpn/__init__.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/__init__.py
@@ -46,6 +46,7 @@ LOG = getLogger()
     default=DEFAULT_CONFIG_DIR,
     show_default=True,
 )
+@click.version_option()
 @click.pass_context
 def ih_openvpn(ctx, **kwargs):  # pylint: disable=unused-argument
     """

--- a/infrahouse_toolkit/cli/ih_openvpn/cmd_sync_google_users/__init__.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/cmd_sync_google_users/__init__.py
@@ -10,10 +10,14 @@ import logging
 import os
 import sys
 from subprocess import CalledProcessError
+from typing import Iterable, Set, Tuple
 
 import click
 
-from infrahouse_toolkit.cli.ih_openvpn.exceptions import GoogleNotConfigured
+from infrahouse_toolkit.cli.ih_openvpn.exceptions import (
+    EmptyDirectory,
+    GoogleNotConfigured,
+)
 from infrahouse_toolkit.cli.ih_openvpn.lib import (
     index_path,
     revoke_client,
@@ -139,6 +143,59 @@ def get_active_directory_users(service_account, admin_subject):
     return users
 
 
+def active_users_across_workspaces(service_account: str, admin_subjects: Iterable[str]) -> Set[str]:
+    """
+    Union the active users of every Workspace, or fail without a partial answer.
+
+    The caller revokes certificates whose owner is missing from the returned set,
+    so an incomplete union is worse than no answer at all: users of a Workspace
+    that was skipped would look deactivated and lose their VPN access. Hence a
+    failure to read any single Workspace fails the whole call.
+
+    :param service_account: Email of the directory-reader service account. The
+                            same account impersonates every subject.
+    :type service_account: str
+    :param admin_subjects: Workspace admins to impersonate, one per tenant.
+    :type admin_subjects: Iterable(str)
+    :return: Primary email addresses of users active in at least one Workspace.
+    :rtype: set(str)
+    :raise GoogleNotConfigured: if any Workspace is not readable yet.
+    :raise EmptyDirectory: if any Workspace reports no active users.
+    """
+    active_users = set()
+    for admin_subject in admin_subjects:
+        workspace_users = get_active_directory_users(service_account, admin_subject)
+        # Refused per Workspace, not on the union: the other tenants' users would
+        # otherwise mask an empty one and its certificates would all be revoked.
+        if not workspace_users:
+            raise EmptyDirectory(f"the directory of {admin_subject} returned no active users")
+
+        LOG.info("Workspace of %s has %d active user(s).", admin_subject, len(workspace_users))
+        active_users |= workspace_users
+
+    return active_users
+
+
+def _default_admin_subjects() -> Tuple[str, ...]:
+    """
+    Resolve the admin subjects to impersonate from the environment.
+
+    ``WIF_ADMIN_SUBJECTS`` (comma-separated, one admin per Workspace tenant) is
+    authoritative. ``WIF_ADMIN_SUBJECT`` is the deprecated single-tenant spelling
+    and is honoured only when the plural variable is absent, so an instance whose
+    Terraform has not been re-applied yet keeps working unchanged.
+
+    :return: Admin subjects in the order they were configured.
+    :rtype: tuple(str)
+    """
+    plural = os.environ.get("WIF_ADMIN_SUBJECTS")
+    if plural:
+        return tuple(subject.strip() for subject in plural.split(",") if subject.strip())
+
+    singular = os.environ.get("WIF_ADMIN_SUBJECT")
+    return (singular,) if singular else ()
+
+
 @click.command(name="sync-google-users")
 @click.option(
     "--service-account",
@@ -147,8 +204,13 @@ def get_active_directory_users(service_account, admin_subject):
 )
 @click.option(
     "--admin-subject",
-    help="Workspace admin to impersonate. Defaults to $WIF_ADMIN_SUBJECT.",
-    default=lambda: os.environ.get("WIF_ADMIN_SUBJECT"),
+    "admin_subjects",
+    help=(
+        "Workspace admin to impersonate; repeatable, one per Workspace tenant. "
+        "Defaults to $WIF_ADMIN_SUBJECTS (comma-separated) or $WIF_ADMIN_SUBJECT."
+    ),
+    multiple=True,
+    default=_default_admin_subjects,
 )
 @click.option(
     "--dry-run",
@@ -166,7 +228,17 @@ def cmd_sync_google_users(ctx: click.Context, **kwargs):
     user certificate whose owner is suspended, deleted or otherwise absent is
     revoked. The server's own certificate is never a candidate.
 
-    CONFIGURATION comes from three environment variables, which on a
+    MULTIPLE WORKSPACES are supported: allowed VPN users may live in separate
+    Google Workspace tenants, so --admin-subject is repeatable -- one admin per
+    tenant. The single service account impersonates each admin in turn (its
+    client id must be authorized for domain-wide delegation in every tenant),
+    and the active users of all tenants are unioned before anything is compared.
+
+    That union is all-or-nothing: if any one tenant cannot be read, the whole run
+    aborts and revokes nothing. Proceeding on a partial union would make every
+    active user of the unreadable tenant look deactivated and revoke them all.
+
+    CONFIGURATION comes from environment variables, which on a
     module-provisioned instance are written by Terraform to
     /opt/openvpn-wif/wif.env (the file holds no secret -- the credential it
     points at is a keyless federation config, not a key):
@@ -174,7 +246,10 @@ def cmd_sync_google_users(ctx: click.Context, **kwargs):
     \b
       GOOGLE_APPLICATION_CREDENTIALS  path to the WIF credential config
       WIF_SA_EMAIL                    directory-reader service account
-      WIF_ADMIN_SUBJECT               Workspace admin to impersonate
+      WIF_ADMIN_SUBJECTS              Workspace admins to impersonate,
+                                      comma-separated, one per tenant
+      WIF_ADMIN_SUBJECT               deprecated single-tenant spelling, used
+                                      only when WIF_ADMIN_SUBJECTS is unset
 
     So a by-hand run on an instance is source-then-invoke. --dry-run first is
     the safe habit: it prints exactly who would be revoked and touches nothing.
@@ -195,18 +270,21 @@ def cmd_sync_google_users(ctx: click.Context, **kwargs):
     when the Google side is not usable yet (most often domain-wide delegation
     not authorized), any other code on a genuine failure. Point --config-dir at
     a different OpenVPN installation, or override the service account / admin
-    subject, with the options below.
+    subjects, with the options below.
     """
     config_dir = ctx.obj["config_dir"]
     service_account = kwargs["service_account"]
-    admin_subject = kwargs["admin_subject"]
+    # Repeats and the same admin arriving from both the option and the
+    # environment only cost a duplicate directory query; dict.fromkeys drops them
+    # while keeping the configured order for readable logs.
+    admin_subjects = tuple(dict.fromkeys(kwargs["admin_subjects"]))
     dry_run = kwargs["dry_run"]
 
     # Absent configuration is the pre-deployment state, not a usage error, so it
     # exits EX_CONFIG rather than click's UsageError.
     for name, value in (
         ("--service-account/$WIF_SA_EMAIL", service_account),
-        ("--admin-subject/$WIF_ADMIN_SUBJECT", admin_subject),
+        ("--admin-subject/$WIF_ADMIN_SUBJECTS", admin_subjects),
     ):
         if not value:
             LOG.info("%s is not set; the Google integration is not configured yet.", name)
@@ -220,15 +298,17 @@ def cmd_sync_google_users(ctx: click.Context, **kwargs):
         sys.exit(EX_CONFIG)
 
     try:
-        active_users = get_active_directory_users(service_account, admin_subject)
+        active_users = active_users_across_workspaces(service_account, admin_subjects)
     except GoogleNotConfigured as err:
+        # A single Workspace we cannot read makes the union incomplete, and every
+        # active user in it would then look deactivated. Abort the whole run
+        # rather than revoke from a partial picture.
         LOG.info("Google Workspace is not configured yet: %s", err)
         sys.exit(EX_CONFIG)
-
-    # An empty directory response would make every certificate look orphaned.
-    # Treat it as a failed lookup rather than as "everyone was deactivated".
-    if not active_users:
-        LOG.error("The directory returned no active users; refusing to revoke every certificate.")
+    except EmptyDirectory as err:
+        # A live query answering with nobody is a failed lookup, not "everyone
+        # was deactivated".
+        LOG.error("%s; refusing to revoke every certificate.", err)
         sys.exit(1)
 
     stale = sorted(certificate for certificate in certificates if certificate.lower() not in active_users)

--- a/infrahouse_toolkit/cli/ih_openvpn/exceptions.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/exceptions.py
@@ -18,3 +18,14 @@ class GoogleNotConfigured(IHOpenVPNError):
     -- and never for failures that appear after a working deployment. The
     command maps it to the ``EX_CONFIG`` (78) exit status.
     """
+
+
+class EmptyDirectory(IHOpenVPNError):
+    """
+    A Workspace answered a directory listing with no active users at all.
+
+    A live query that returns nobody is a failed lookup, not the news that every
+    employee was deactivated: acting on it would revoke every certificate. Unlike
+    :py:class:`GoogleNotConfigured` this is not an expected pre-deployment state,
+    so the command maps it to exit status 1.
+    """

--- a/infrahouse_toolkit/cli/ih_openvpn/tests/test_sync_google_users.py
+++ b/infrahouse_toolkit/cli/ih_openvpn/tests/test_sync_google_users.py
@@ -47,20 +47,36 @@ def _config_dir(tmp_path):
     return str(tmp_path)
 
 
-def run(config_dir, extra_args=None, **kwargs):
+def run(config_dir, extra_args=None, subjects=("admin@infrahouse.com",), **kwargs):
     """Invoke the command with the context the ih-openvpn group would normally supply."""
+    admin_args = []
+    for subject in subjects:
+        admin_args += ["--admin-subject", subject]
     return CliRunner().invoke(
         cmd_sync_google_users,
-        [
-            "--service-account",
-            "sa@example.iam.gserviceaccount.com",
-            "--admin-subject",
-            "admin@infrahouse.com",
-        ]
-        + (extra_args or []),
+        ["--service-account", "sa@example.iam.gserviceaccount.com"] + admin_args + (extra_args or []),
         obj={"easyrsa_path": "/usr/share/easy-rsa/easyrsa", "config_dir": config_dir},
         **kwargs,
     )
+
+
+def by_subject(directories):
+    """
+    Build a ``get_active_directory_users`` stub answering per impersonated admin.
+
+    :param directories: Active users keyed by the admin subject that reads them.
+                        A value that is an exception is raised instead.
+    :type directories: dict
+    :return: A callable with the signature of ``get_active_directory_users``.
+    """
+
+    def _stub(_service_account, admin_subject):
+        answer = directories[admin_subject]
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+    return _stub
 
 
 def test_dry_run_revokes_nothing(config_dir):
@@ -205,6 +221,179 @@ def test_case_insensitive_match(config_dir):
             result = run(config_dir)
     assert result.exit_code == 0
     revoke.assert_not_called()
+
+
+def test_unions_active_users_across_workspaces(config_dir):
+    """
+    A certificate is stale only when its owner is inactive in *every* Workspace.
+
+    alice is active in the first tenant and absent from the second; she must
+    survive. bob is in neither, so only bob is revoked.
+    """
+    with mock.patch.object(
+        sync_module,
+        "get_active_directory_users",
+        side_effect=by_subject(
+            {
+                "admin@infrahouse.com": {"alice@infrahouse.com"},
+                "admin@infrahouse.solutions": {"carol@infrahouse.solutions"},
+            }
+        ),
+    ):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir, subjects=("admin@infrahouse.com", "admin@infrahouse.solutions"))
+    assert result.exit_code == 0
+    revoke.assert_called_once_with("/usr/share/easy-rsa/easyrsa", "bob@infrahouse.com", config_dir)
+
+
+def test_one_unreadable_workspace_revokes_nothing(config_dir):
+    """
+    A Workspace that cannot be read aborts the whole run -- the mis-revocation guard.
+
+    Continuing with a partial union would diff every certificate against the
+    first tenant alone, so every active user of the unreadable tenant would look
+    deactivated and lose VPN access. Nothing may be revoked, and the exit status
+    stays 78 so the cron wrapper keeps quiet while delegation is authorized.
+    """
+    with mock.patch.object(
+        sync_module,
+        "get_active_directory_users",
+        side_effect=by_subject(
+            {
+                "admin@infrahouse.com": {"carol@infrahouse.com"},
+                "admin@infrahouse.solutions": GoogleNotConfigured("domain-wide delegation is not authorized"),
+            }
+        ),
+    ):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir, subjects=("admin@infrahouse.com", "admin@infrahouse.solutions"))
+    # Both alice and bob are stale against the first tenant alone -- exactly what
+    # must not happen.
+    assert result.exit_code == EX_CONFIG
+    revoke.assert_not_called()
+
+
+def test_one_empty_workspace_revokes_nothing(config_dir):
+    """
+    An empty answer from one tenant is a failed lookup, not a mass deactivation.
+
+    The other tenants' users would hide it in the union, so the refusal is per
+    Workspace. Exit 1, because unlike unauthorized delegation this is not a
+    known-incomplete-setup state and deserves an operator's attention.
+    """
+    with mock.patch.object(
+        sync_module,
+        "get_active_directory_users",
+        side_effect=by_subject(
+            {
+                "admin@infrahouse.com": {"alice@infrahouse.com"},
+                "admin@infrahouse.solutions": set(),
+            }
+        ),
+    ):
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = run(config_dir, subjects=("admin@infrahouse.com", "admin@infrahouse.solutions"))
+    assert result.exit_code == 1
+    revoke.assert_not_called()
+
+
+def test_repeated_subject_is_queried_once(config_dir):
+    """The same admin given twice costs one directory query, not two."""
+    with mock.patch.object(
+        sync_module, "get_active_directory_users", return_value={"alice@infrahouse.com"}
+    ) as directory:
+        with mock.patch.object(sync_module, "revoke_client"):
+            result = run(config_dir, subjects=("admin@infrahouse.com", "admin@infrahouse.com"))
+    assert result.exit_code == 0
+    directory.assert_called_once_with("sa@example.iam.gserviceaccount.com", "admin@infrahouse.com")
+
+
+def test_deprecated_singular_env_var_still_works(config_dir, monkeypatch):
+    """
+    An instance whose Terraform still writes only WIF_ADMIN_SUBJECT behaves as before.
+
+    Back-compat matters because this package ships ahead of the module that
+    starts emitting the plural variable.
+    """
+    monkeypatch.delenv("WIF_ADMIN_SUBJECTS", raising=False)
+    monkeypatch.setenv("WIF_SA_EMAIL", "sa@example.iam.gserviceaccount.com")
+    monkeypatch.setenv("WIF_ADMIN_SUBJECT", "admin@infrahouse.com")
+
+    with mock.patch.object(
+        sync_module, "get_active_directory_users", return_value={"alice@infrahouse.com"}
+    ) as directory:
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = CliRunner().invoke(
+                cmd_sync_google_users,
+                [],
+                obj={"easyrsa_path": "/usr/share/easy-rsa/easyrsa", "config_dir": config_dir},
+            )
+    assert result.exit_code == 0
+    directory.assert_called_once_with("sa@example.iam.gserviceaccount.com", "admin@infrahouse.com")
+    revoke.assert_called_once_with("/usr/share/easy-rsa/easyrsa", "bob@infrahouse.com", config_dir)
+
+
+def test_plural_env_var_wins_over_the_singular(config_dir, monkeypatch):
+    """WIF_ADMIN_SUBJECTS is authoritative; the deprecated singular is ignored beside it."""
+    monkeypatch.setenv("WIF_SA_EMAIL", "sa@example.iam.gserviceaccount.com")
+    monkeypatch.setenv("WIF_ADMIN_SUBJECT", "stale@infrahouse.com")
+    monkeypatch.setenv("WIF_ADMIN_SUBJECTS", " admin@infrahouse.com , admin@infrahouse.solutions ")
+
+    with mock.patch.object(
+        sync_module,
+        "get_active_directory_users",
+        side_effect=by_subject(
+            {
+                "admin@infrahouse.com": {"alice@infrahouse.com"},
+                "admin@infrahouse.solutions": {"bob@infrahouse.com"},
+            }
+        ),
+    ) as directory:
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = CliRunner().invoke(
+                cmd_sync_google_users,
+                [],
+                obj={"easyrsa_path": "/usr/share/easy-rsa/easyrsa", "config_dir": config_dir},
+            )
+    assert result.exit_code == 0
+    assert [call.args[1] for call in directory.call_args_list] == [
+        "admin@infrahouse.com",
+        "admin@infrahouse.solutions",
+    ]
+    revoke.assert_not_called()
+
+
+def test_single_element_plural_env_var(config_dir, monkeypatch):
+    """One admin in WIF_ADMIN_SUBJECTS is just the single-Workspace case."""
+    monkeypatch.setenv("WIF_SA_EMAIL", "sa@example.iam.gserviceaccount.com")
+    monkeypatch.delenv("WIF_ADMIN_SUBJECT", raising=False)
+    monkeypatch.setenv("WIF_ADMIN_SUBJECTS", "admin@infrahouse.com")
+
+    with mock.patch.object(
+        sync_module, "get_active_directory_users", return_value={"alice@infrahouse.com"}
+    ) as directory:
+        with mock.patch.object(sync_module, "revoke_client") as revoke:
+            result = CliRunner().invoke(
+                cmd_sync_google_users,
+                [],
+                obj={"easyrsa_path": "/usr/share/easy-rsa/easyrsa", "config_dir": config_dir},
+            )
+    assert result.exit_code == 0
+    directory.assert_called_once_with("sa@example.iam.gserviceaccount.com", "admin@infrahouse.com")
+    revoke.assert_called_once_with("/usr/share/easy-rsa/easyrsa", "bob@infrahouse.com", config_dir)
+
+
+def test_exits_ex_config_without_any_admin_subject(config_dir, monkeypatch):
+    """Neither environment variable set is the pre-deployment state, not a usage error."""
+    monkeypatch.delenv("WIF_ADMIN_SUBJECTS", raising=False)
+    monkeypatch.delenv("WIF_ADMIN_SUBJECT", raising=False)
+
+    result = CliRunner().invoke(
+        cmd_sync_google_users,
+        ["--service-account", "sa@example.iam.gserviceaccount.com"],
+        obj={"easyrsa_path": "/usr/share/easy-rsa/easyrsa", "config_dir": config_dir},
+    )
+    assert result.exit_code == EX_CONFIG
 
 
 def test_continues_after_a_failed_revocation(config_dir):

--- a/infrahouse_toolkit/cli/ih_s3_reprepro/__init__.py
+++ b/infrahouse_toolkit/cli/ih_s3_reprepro/__init__.py
@@ -89,6 +89,7 @@ LOG = getLogger()
         ]
     ),
 )
+@click.version_option()
 @click.pass_context
 def ih_s3_reprepro(*args, **kwargs):  # pylint: disable=unused-argument
     """

--- a/infrahouse_toolkit/cli/ih_skeema/__init__.py
+++ b/infrahouse_toolkit/cli/ih_skeema/__init__.py
@@ -56,6 +56,7 @@ LOG = getLogger()
     "The secret value must be a JSON with keys 'username' and 'password'.",
     default=None,
 )
+@click.version_option()
 @click.pass_context
 def ih_skeema(ctx, **kwargs):  # pylint: disable=unused-argument
     """


### PR DESCRIPTION
Two independent changes, kept on one branch deliberately.

## 1. Revoke across multiple Google Workspace tenants

Allowed VPN users can live in **separate** Google Workspaces — an organization may run two entirely distinct Workspace tenants, each with its own admin — but `ih-openvpn sync-google-users` impersonated a single admin and read a single directory — so only the first tenant's deactivated users were ever revoked.

`--admin-subject` is now repeatable, one admin per tenant, defaulting to `$WIF_ADMIN_SUBJECTS` (comma-separated). The deprecated `$WIF_ADMIN_SUBJECT` is still honoured when the plural variable is absent, so an instance whose Terraform has not been re-applied keeps working unchanged. One service account still impersonates every subject, and `customer='my_customer'` is untouched — it already resolves per-subject to that subject's own Workspace.

### The union is all-or-nothing

This is the part worth reviewing. The command revokes any certificate whose owner is **missing** from the active-user set, so reading only *some* tenants is worse than reading none: every active user of a skipped tenant would look deactivated and lose VPN access.

- A Workspace that cannot be read (delegation not authorized, 401/403, transient refresh failure) aborts the whole run with **78**, revoking nothing.
- A Workspace answering with **zero** active users aborts with **1**. The emptiness check is per-Workspace rather than on the union, because the other tenants' users would otherwise mask it.

There is deliberately no "skip the failed Workspace and continue" mode.

`active_users_across_workspaces()` raises (`GoogleNotConfigured` / the new `EmptyDirectory`) instead of exiting; only the Click entry point converts to `sys.exit`, per the coding standard.

## 2. `--version` on four CLI entry points

`ih-openvpn --version` failed with a usage error. Four entry points were missing `@click.version_option()` while the other ten already had it: `ih-certbot`, `ih-openvpn`, `ih-s3-reprepro`, `ih-skeema`. All 14 `ih-*` commands now report the installed version. Nested subgroups (`ih-aws autoscaling`, `ih-elastic cat`, …) are intentionally left alone.

## Test plan

`306 passed, 4 skipped`; `make lint` clean at pylint 10.00/10.

New cases in `test_sync_google_users.py`:

- **Union across two tenants** — a user active in *either* Workspace survives; one active in neither is revoked.
- **Second tenant fails auth → exit 78 and `revoke_client` never called.** This is the mis-revocation regression guard: without it, both certificates would be diffed against the first tenant alone.
- **Second tenant returns empty** → exit 1, zero revocations.
- **Back-compat** — `$WIF_ADMIN_SUBJECT` alone behaves exactly as before; plural wins over singular (with whitespace trimming); single-element plural equals the single-tenant case.
- Repeated subject is queried once; neither variable set → 78.

`--version` was verified by invoking it on every entry point via `CliRunner` — all 14 exit 0 with a version string.

## Rollout

This ships **first** of three repos. Needs a `bumpversion minor` (2.61.0 → 2.62.0) on `main` after merge, released to PyPI/Debian, **before** terraform-aws-openvpn starts emitting `WIF_ADMIN_SUBJECTS` and puppet-code's wrapper accepts it. Backward compatible, so the ordering is a safety margin rather than a hard break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
