### PR TITLE
fix: read vulnerability severity from records without database_specific

### DIFF
--- a/infrahouse_toolkit/cli/ih_github/cmd_scan/__init__.py
+++ b/infrahouse_toolkit/cli/ih_github/cmd_scan/__init__.py
@@ -6,7 +6,6 @@
     See ``ih-github scan --help`` for more details.
 """
 
-import json
 import logging
 import sys
 from datetime import datetime, timedelta
@@ -16,10 +15,19 @@ from subprocess import PIPE, Popen
 import click
 
 from infrahouse_toolkit.cli.utils import check_dependencies
+from infrahouse_toolkit.osv import (
+    SEVERITY_CRITICAL,
+    SEVERITY_HIGH,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    SEVERITY_MODERATE,
+)
+from infrahouse_toolkit.osv.scan_report import ScanReport
 from infrahouse_toolkit.terraform.githubpr import GitHubPR
 
 LOG = logging.getLogger()
 DEPENDENCIES = ["osv-scanner"]
+DEFAULT_SLA_DAYS = 30
 
 
 @click.command(
@@ -65,11 +73,11 @@ def cmd_scan(ctx, *args, **kwargs):
     cmd.extend(cmd_args)
     cmd.extend(["./"])
     sla_map = {
-        "CRITICAL": kwargs["sla_critical"],
-        "HIGH": kwargs["sla_high"],
-        "MODERATE": kwargs["sla_medium"],
-        "MEDIUM": kwargs["sla_medium"],
-        "LOW": kwargs["sla_low"],
+        SEVERITY_CRITICAL: kwargs["sla_critical"],
+        SEVERITY_HIGH: kwargs["sla_high"],
+        SEVERITY_MODERATE: kwargs["sla_medium"],
+        SEVERITY_MEDIUM: kwargs["sla_medium"],
+        SEVERITY_LOW: kwargs["sla_low"],
     }
     comment = None
     try:
@@ -84,11 +92,11 @@ def cmd_scan(ctx, *args, **kwargs):
             if return_code == 1:
                 comment = "# Vulnerabilities report\n"
                 comment += vuln_table.decode()
-                for vuln in _get_vulnerability_details(osv_config, cmd_args):
-                    future_date = datetime.now() + timedelta(days=sla_map.get(vuln["severity"], 30))
+                for vuln in ScanReport(config_file=osv_config, extra_args=cmd_args).vulnerabilities:
+                    future_date = datetime.now() + timedelta(days=sla_map.get(vuln.severity, DEFAULT_SLA_DAYS))
                     comment += f"""
-## {vuln["name"]}=={vuln["version"]}
-The package `{vuln["name"]}` (version {vuln["version"]}) has a {vuln["severity"]}-severity vulnerability.
+## {vuln.package}
+The package `{vuln.package.name}` (version {vuln.package.version}) has a {vuln.severity}-severity vulnerability.
 
 If you're able to upgrade to a non-vulnerable version, we recommend doing so.
 If upgrading isn't currently possible, consider adding this entry to your `{osv_config}` file
@@ -96,7 +104,7 @@ in the root directory of this repository.
 
 ```
 [[IgnoredVulns]]
-id = "{vuln["id"]}"
+id = "{vuln.id}"
 ignoreUntil = {future_date.strftime("%Y-%m-%d")} # Optional exception expiry date
 reason = "Detailed explanation why the vulnerability is ignored and how it is planned to be fixed."
 ```
@@ -117,41 +125,3 @@ reason = "Detailed explanation why the vulnerability is ignored and how it is pl
                 pull_request.publish_comment(comment)
 
     sys.exit(return_code)
-
-
-def _get_vulnerability_details(config_file, extra_args):
-    """
-    returns a JSON
-    [
-        {
-            name: "pymysql"
-            version: "1.2.3"
-            id: "GHSA-7wqh-767x-r66v"
-            severity: "MODERATE"
-        }
-    ]
-    """
-    cmd = ["osv-scanner", "scan", "--format", "json", "--recursive", "--verbosity", "warn"]
-    if osp.exists(config_file):
-        cmd.extend(["--config", config_file])
-    cmd.extend(extra_args)
-    cmd.extend(["./"])
-    return_value = []
-    with Popen(cmd, stderr=PIPE, stdout=PIPE) as proc:
-        LOG.debug("Launched command: %s", " ".join(cmd))
-        cout, cerr = proc.communicate()
-        if cerr:
-            LOG.error(cerr)
-        response = json.loads(cout)
-        for result in response["results"]:
-            for package_item in result["packages"]:
-                for vuln in package_item["vulnerabilities"]:
-                    return_value.append(
-                        {
-                            "name": package_item["package"]["name"],
-                            "version": package_item["package"]["version"],
-                            "id": vuln["id"],
-                            "severity": vuln["database_specific"]["severity"],
-                        }
-                    )
-        return return_value

--- a/infrahouse_toolkit/osv/__init__.py
+++ b/infrahouse_toolkit/osv/__init__.py
@@ -1,0 +1,10 @@
+"""
+Classes to work with vulnerability reports produced by `osv-scanner <https://google.github.io/osv-scanner/>`_.
+"""
+
+SEVERITY_CRITICAL = "CRITICAL"
+SEVERITY_HIGH = "HIGH"
+SEVERITY_MEDIUM = "MEDIUM"
+SEVERITY_MODERATE = "MODERATE"
+SEVERITY_LOW = "LOW"
+SEVERITY_UNKNOWN = "UNKNOWN"

--- a/infrahouse_toolkit/osv/package.py
+++ b/infrahouse_toolkit/osv/package.py
@@ -1,0 +1,46 @@
+"""
+Module for Package class - a package osv-scanner found in a dependency lock file.
+"""
+
+
+class Package:
+    """
+    A package osv-scanner found in a dependency lock file.
+
+    :param package: A ``package`` section of the osv-scanner JSON report.
+    :type package: dict
+    """
+
+    def __init__(self, package: dict):
+        self._package = package
+
+    def __str__(self) -> str:
+        """
+        :return: Package name and version, e.g. ``aiohttp==3.14.1``.
+        :rtype: str
+        """
+        return f"{self.name}=={self.version}"
+
+    @property
+    def ecosystem(self) -> str:
+        """
+        :return: Ecosystem the package comes from, e.g. ``PyPI``.
+        :rtype: str
+        """
+        return self._package["ecosystem"]
+
+    @property
+    def name(self) -> str:
+        """
+        :return: Package name, e.g. ``aiohttp``.
+        :rtype: str
+        """
+        return self._package["name"]
+
+    @property
+    def version(self) -> str:
+        """
+        :return: Installed version of the package, e.g. ``3.14.1``.
+        :rtype: str
+        """
+        return self._package["version"]

--- a/infrahouse_toolkit/osv/scan_report.py
+++ b/infrahouse_toolkit/osv/scan_report.py
@@ -1,0 +1,95 @@
+"""
+Module for ScanReport class - a vulnerability report produced by osv-scanner.
+"""
+
+import json
+from functools import cached_property
+from logging import getLogger
+from os import path as osp
+from subprocess import PIPE, Popen
+from typing import List, Optional
+
+from infrahouse_toolkit.osv.package import Package
+from infrahouse_toolkit.osv.vulnerability import Vulnerability
+
+LOG = getLogger()
+
+
+class ScanReport:  # pylint: disable=too-few-public-methods
+    """
+    A vulnerability report osv-scanner produces for a directory.
+
+    The scan runs on the first access to the report and its result is remembered.
+
+    :param path: Directory to scan.
+    :type path: str
+    :param config_file: Path to an osv-scanner configuration file.
+        The option is passed to osv-scanner only if the file exists.
+    :type config_file: str
+    :param extra_args: Extra arguments to pass to osv-scanner.
+    :type extra_args: list
+    """
+
+    def __init__(self, path: str = "./", config_file: Optional[str] = None, extra_args: Optional[List[str]] = None):
+        self._path = path
+        self._config_file = config_file
+        self._extra_args = extra_args or []
+
+    @property
+    def vulnerabilities(self) -> List[Vulnerability]:
+        """
+        :return: Vulnerabilities osv-scanner found in all scanned packages.
+        :rtype: list
+        """
+        vulnerabilities = []
+        for result in self._report.get("results", []):
+            for package_item in result.get("packages", []):
+                package = Package(package_item.get("package", {}))
+                cvss_scores = self._cvss_scores(package_item)
+                for record in package_item.get("vulnerabilities", []):
+                    vulnerabilities.append(
+                        Vulnerability(record, package=package, cvss_score=cvss_scores.get(record["id"]))
+                    )
+
+        return vulnerabilities
+
+    @cached_property
+    def _report(self) -> dict:
+        """
+        :return: The osv-scanner JSON report.
+        :rtype: dict
+        """
+        cmd = ["osv-scanner", "scan", "--format", "json", "--recursive", "--verbosity", "warn"]
+        config_file = self._config_file
+        if config_file and osp.exists(config_file):
+            cmd.extend(["--config", config_file])
+        cmd.extend(self._extra_args)
+        cmd.append(self._path)
+        with Popen(cmd, stderr=PIPE, stdout=PIPE) as proc:
+            LOG.debug("Launched command: %s", " ".join(cmd))
+            cout, cerr = proc.communicate()
+            if cerr:
+                LOG.error(cerr.decode())
+
+            return json.loads(cout)
+
+    @staticmethod
+    def _cvss_scores(package_item: dict) -> dict:
+        """
+        Map every vulnerability identifier of a package to its CVSS score.
+
+        osv-scanner calculates the score per group of aliases - a CVE and its PYSEC
+        and GHSA records belong to one group - so any identifier of a group
+        resolves to the score of the group.
+
+        :param package_item: A package entry of the osv-scanner JSON report.
+        :type package_item: dict
+        :return: Vulnerability identifiers mapped to CVSS scores,
+            e.g. ``{"PYSEC-2026-3545": "7.1"}``.
+        :rtype: dict
+        """
+        return {
+            vuln_id: group.get("max_severity")
+            for group in package_item.get("groups", [])
+            for vuln_id in group.get("ids", [])
+        }

--- a/infrahouse_toolkit/osv/tests/conftest.py
+++ b/infrahouse_toolkit/osv/tests/conftest.py
@@ -1,0 +1,97 @@
+"""Fixtures with osv-scanner reports."""
+
+import json
+
+import pytest
+
+# A trimmed down report osv-scanner 2.4.0 produced for a requirements.txt
+# with aiohttp==3.14.1. Every vulnerability is described by two OSV records:
+# one from the PyPI Advisory Database (PYSEC) and one from the GitHub Advisory
+# Database (GHSA). Only the GHSA records have the "database_specific" section.
+AIOHTTP_REPORT = {
+    "results": [
+        {
+            "source": {"path": "/code/requirements.txt", "type": "lockfile"},
+            "packages": [
+                {
+                    "package": {"name": "aiohttp", "version": "3.14.1", "ecosystem": "PyPI"},
+                    "vulnerabilities": [
+                        {
+                            "id": "PYSEC-2026-3545",
+                            "aliases": ["CVE-2026-69244", "GHSA-cq5v-8q36-5273"],
+                            "severity": [
+                                {
+                                    "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
+                                    "type": "CVSS_V4",
+                                }
+                            ],
+                        },
+                        {
+                            "id": "GHSA-cq5v-8q36-5273",
+                            "aliases": ["CVE-2026-69244"],
+                            "database_specific": {"cwe_ids": ["CWE-125"], "severity": "HIGH"},
+                        },
+                        {
+                            "id": "PYSEC-2026-3546",
+                            "aliases": ["CVE-2026-69243", "GHSA-mfx4-hv73-q22v"],
+                        },
+                        {
+                            "id": "GHSA-mfx4-hv73-q22v",
+                            "aliases": ["CVE-2026-69243"],
+                            "database_specific": {"cwe_ids": ["CWE-444"], "severity": "MODERATE"},
+                        },
+                    ],
+                    "groups": [
+                        {
+                            "ids": ["PYSEC-2026-3545", "GHSA-cq5v-8q36-5273"],
+                            "aliases": ["CVE-2026-69244", "GHSA-cq5v-8q36-5273", "PYSEC-2026-3545"],
+                            "max_severity": "7.1",
+                        },
+                        {
+                            "ids": ["PYSEC-2026-3546", "GHSA-mfx4-hv73-q22v"],
+                            "aliases": ["CVE-2026-69243", "GHSA-mfx4-hv73-q22v", "PYSEC-2026-3546"],
+                            "max_severity": "6.3",
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+}
+
+# osv-scanner omits the "vulnerabilities" and "groups" keys altogether
+# for packages without vulnerabilities. Such packages show up in the report
+# when the license scanning is enabled.
+CLEAN_PACKAGE_REPORT = {
+    "results": [
+        {
+            "source": {"path": "/code/requirements.txt", "type": "lockfile"},
+            "packages": [
+                {
+                    "package": {"name": "certifi", "version": "2025.10.5", "ecosystem": "PyPI"},
+                    "licenses": ["MPL-2.0"],
+                    "license_violations": ["MPL-2.0"],
+                }
+            ],
+        }
+    ]
+}
+
+
+@pytest.fixture
+def aiohttp_report():
+    """
+    :return: An osv-scanner report where the same vulnerabilities come
+        from the PyPI and the GitHub advisory databases.
+    :rtype: bytes
+    """
+    return json.dumps(AIOHTTP_REPORT).encode()
+
+
+@pytest.fixture
+def clean_package_report():
+    """
+    :return: An osv-scanner report with a package that has no vulnerabilities.
+    :rtype: bytes
+    """
+    return json.dumps(CLEAN_PACKAGE_REPORT).encode()

--- a/infrahouse_toolkit/osv/tests/test_scan_report.py
+++ b/infrahouse_toolkit/osv/tests/test_scan_report.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for :py:mod:`infrahouse_toolkit.osv.scan_report`.
+
+osv-scanner reports a CVSS score per group of aliases rather than per record,
+so a record without its own severity rating gets the score of its group.
+"""
+
+import json
+from unittest import mock
+
+import pytest
+
+from infrahouse_toolkit.osv import SEVERITY_UNKNOWN
+from infrahouse_toolkit.osv.scan_report import ScanReport
+
+
+@pytest.fixture(name="popen")
+def _popen():
+    """Patch Popen so that osv-scanner isn't actually executed."""
+
+    def _mock(stdout, stderr=b""):
+        proc = mock.MagicMock()
+        proc.communicate.return_value = (stdout, stderr)
+        popen = mock.MagicMock()
+        popen.return_value.__enter__.return_value = proc
+        return popen
+
+    return _mock
+
+
+def test_vulnerabilities(popen, aiohttp_report):
+    """Every OSV record of every package makes it into the report."""
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen(aiohttp_report)):
+        vulnerabilities = ScanReport().vulnerabilities
+
+    assert [(vuln.id, vuln.severity) for vuln in vulnerabilities] == [
+        ("PYSEC-2026-3545", "HIGH"),
+        ("GHSA-cq5v-8q36-5273", "HIGH"),
+        ("PYSEC-2026-3546", "MEDIUM"),
+        ("GHSA-mfx4-hv73-q22v", "MODERATE"),
+    ]
+    assert all(str(vuln.package) == "aiohttp==3.14.1" for vuln in vulnerabilities)
+
+
+def test_score_comes_from_the_group_of_aliases(popen, aiohttp_report):
+    """A PYSEC record borrows the score osv-scanner calculated for its group."""
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen(aiohttp_report)):
+        scores = {vuln.id: vuln.score for vuln in ScanReport().vulnerabilities}
+
+    assert scores == {
+        "PYSEC-2026-3545": 7.1,
+        "GHSA-cq5v-8q36-5273": 7.1,
+        "PYSEC-2026-3546": 6.3,
+        "GHSA-mfx4-hv73-q22v": 6.3,
+    }
+
+
+def test_package_without_vulnerabilities(popen, clean_package_report):
+    """A package with no vulnerabilities has neither a vulnerabilities nor a groups key."""
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen(clean_package_report)):
+        assert ScanReport().vulnerabilities == []
+
+
+def test_empty_report(popen):
+    """osv-scanner found nothing to scan."""
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen(json.dumps({"results": []}).encode())):
+        assert ScanReport().vulnerabilities == []
+
+
+def test_report_without_groups(popen):
+    """Vulnerabilities are still reported when osv-scanner didn't calculate a score."""
+    report = {
+        "results": [
+            {
+                "packages": [
+                    {
+                        "package": {"name": "aiohttp", "version": "3.14.1", "ecosystem": "PyPI"},
+                        "vulnerabilities": [{"id": "PYSEC-2026-3545"}],
+                    }
+                ]
+            }
+        ]
+    }
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen(json.dumps(report).encode())):
+        vulnerabilities = ScanReport().vulnerabilities
+
+    assert len(vulnerabilities) == 1
+    assert vulnerabilities[0].severity == SEVERITY_UNKNOWN
+
+
+def test_scan_command(popen, aiohttp_report, tmp_path):
+    """The configuration file is passed to osv-scanner only when it exists."""
+    config_file = tmp_path / "osv-scanner.toml"
+    config_file.write_text("[[IgnoredVulns]]\n", encoding="utf-8")
+
+    popen_mock = popen(aiohttp_report)
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen_mock):
+        assert ScanReport(config_file=str(config_file), extra_args=["--experimental-only-packages"]).vulnerabilities
+
+    cmd = popen_mock.call_args[0][0]
+    assert cmd[:2] == ["osv-scanner", "scan"]
+    assert cmd[-4:] == ["--config", str(config_file), "--experimental-only-packages", "./"]
+
+
+def test_scan_command_without_config(popen, aiohttp_report, tmp_path):
+    """A missing configuration file isn't passed to osv-scanner."""
+    popen_mock = popen(aiohttp_report)
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen_mock):
+        assert ScanReport(config_file=str(tmp_path / "missing.toml")).vulnerabilities
+
+    assert "--config" not in popen_mock.call_args[0][0]
+
+
+def test_report_is_scanned_once(popen, aiohttp_report):
+    """The scan is expensive, so its result is remembered."""
+    popen_mock = popen(aiohttp_report)
+    with mock.patch("infrahouse_toolkit.osv.scan_report.Popen", popen_mock):
+        report = ScanReport()
+        assert report.vulnerabilities
+        assert report.vulnerabilities
+
+    popen_mock.assert_called_once()

--- a/infrahouse_toolkit/osv/tests/test_vulnerability.py
+++ b/infrahouse_toolkit/osv/tests/test_vulnerability.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for :py:mod:`infrahouse_toolkit.osv.vulnerability`.
+
+The severity of a vulnerability comes from two different places depending on
+what database published the record. GitHub advisories carry a severity rating,
+records from other databases don't have one at all - for those the rating has to
+be calculated from the CVSS score. Reading the rating unconditionally used to
+crash ``ih-github scan`` with a KeyError as soon as a PYSEC record showed up.
+"""
+
+import pytest
+
+from infrahouse_toolkit.osv import SEVERITY_UNKNOWN
+from infrahouse_toolkit.osv.package import Package
+from infrahouse_toolkit.osv.vulnerability import Vulnerability
+
+PACKAGE = Package({"name": "aiohttp", "version": "3.14.1", "ecosystem": "PyPI"})
+
+
+def test_severity_from_github_advisory():
+    """A GitHub advisory tells its severity rating."""
+    vuln = Vulnerability(
+        {"id": "GHSA-cq5v-8q36-5273", "database_specific": {"severity": "HIGH"}},
+        package=PACKAGE,
+        cvss_score="7.1",
+    )
+    assert vuln.severity == "HIGH"
+
+
+def test_severity_of_pysec_record_comes_from_score():
+    """A PYSEC record has no database_specific section, so the score gives the rating."""
+    vuln = Vulnerability({"id": "PYSEC-2026-3545"}, package=PACKAGE, cvss_score="7.1")
+    assert vuln.severity == "HIGH"
+    assert vuln.score == 7.1
+
+
+def test_severity_is_unknown_without_a_rating_and_a_score():
+    """Neither source knows the severity - the vulnerability is still reported."""
+    vuln = Vulnerability({"id": "PYSEC-2026-3545"}, package=PACKAGE)
+    assert vuln.severity == SEVERITY_UNKNOWN
+    assert vuln.score is None
+
+
+def test_null_database_specific_does_not_crash():
+    """A record may carry an empty database_specific section."""
+    vuln = Vulnerability({"id": "PYSEC-2026-3545", "database_specific": None}, package=PACKAGE, cvss_score="9.9")
+    assert vuln.severity == "CRITICAL"
+
+
+def test_lowercase_rating_is_normalized():
+    """The SLA map is keyed by uppercase ratings."""
+    vuln = Vulnerability({"id": "GHSA-cq5v-8q36-5273", "database_specific": {"severity": "moderate"}}, package=PACKAGE)
+    assert vuln.severity == "MODERATE"
+
+
+def test_vulnerability_knows_its_package():
+    """The report is written per package."""
+    vuln = Vulnerability({"id": "PYSEC-2026-3545"}, package=PACKAGE, cvss_score="7.1")
+    assert vuln.id == "PYSEC-2026-3545"
+    assert vuln.package.name == "aiohttp"
+    assert str(vuln.package) == "aiohttp==3.14.1"
+    assert str(vuln) == "PYSEC-2026-3545(HIGH)"
+
+
+@pytest.mark.parametrize(
+    "cvss_score, expected_severity",
+    [
+        ("10.0", "CRITICAL"),
+        ("9.0", "CRITICAL"),
+        ("8.9", "HIGH"),
+        ("7.0", "HIGH"),
+        ("6.9", "MEDIUM"),
+        ("4.0", "MEDIUM"),
+        ("3.9", "LOW"),
+        ("0.1", "LOW"),
+        ("0.0", SEVERITY_UNKNOWN),
+        (None, SEVERITY_UNKNOWN),
+        ("", SEVERITY_UNKNOWN),
+        ("not a score", SEVERITY_UNKNOWN),
+    ],
+)
+def test_severity_scale(cvss_score, expected_severity):
+    """CVSS scores map onto the qualitative severity rating scale."""
+    vuln = Vulnerability({"id": "PYSEC-2026-3545"}, package=PACKAGE, cvss_score=cvss_score)
+    assert vuln.severity == expected_severity

--- a/infrahouse_toolkit/osv/vulnerability.py
+++ b/infrahouse_toolkit/osv/vulnerability.py
@@ -1,0 +1,120 @@
+"""
+Module for Vulnerability class - a vulnerability of a package osv-scanner reported.
+"""
+
+from logging import getLogger
+from typing import Optional
+
+from infrahouse_toolkit.osv import (
+    SEVERITY_CRITICAL,
+    SEVERITY_HIGH,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    SEVERITY_UNKNOWN,
+)
+from infrahouse_toolkit.osv.package import Package
+
+LOG = getLogger()
+
+
+class Vulnerability:
+    """
+    A vulnerability of a package as osv-scanner reports it.
+
+    :param record: An OSV record from the ``vulnerabilities`` list of a package.
+    :type record: dict
+    :param package: The vulnerable package.
+    :type package: Package
+    :param cvss_score: CVSS base score osv-scanner calculated for the record.
+        osv-scanner reports it as a string, e.g. ``"7.1"``.
+    :type cvss_score: str
+    """
+
+    def __init__(self, record: dict, package: Package, cvss_score: Optional[str] = None):
+        self._record = record
+        self._package = package
+        self._cvss_score = cvss_score
+
+    def __str__(self) -> str:
+        """
+        :return: Vulnerability identifier and its severity, e.g. ``PYSEC-2026-3545(HIGH)``.
+        :rtype: str
+        """
+        return f"{self.id}({self.severity})"
+
+    @property
+    def id(self) -> str:
+        """
+        :return: OSV identifier of the vulnerability, e.g. ``PYSEC-2026-3545``.
+        :rtype: str
+        """
+        return self._record["id"]
+
+    @property
+    def package(self) -> Package:
+        """
+        :return: The package this vulnerability was found in.
+        :rtype: Package
+        """
+        return self._package
+
+    @property
+    def score(self) -> Optional[float]:
+        """
+        :return: CVSS base score of the vulnerability, e.g. ``7.1``.
+            ``None`` if osv-scanner didn't report a score for the record.
+        :rtype: float
+        """
+        cvss_score = self._cvss_score
+        if not cvss_score:
+            return None
+
+        try:
+            return float(cvss_score)
+        except ValueError:
+            LOG.warning("%r is not a valid CVSS score.", cvss_score)
+            return None
+
+    @property
+    def severity(self) -> str:
+        """
+        Qualitative severity rating of the vulnerability.
+
+        GitHub advisories carry the rating in their ``database_specific`` section.
+        Records from other databases - PYSEC and such - don't have that section at all,
+        so for those the rating comes from the CVSS score.
+
+        :return: Severity rating, e.g. ``HIGH``. ``UNKNOWN`` if neither the record
+            nor the CVSS score tells it.
+        :rtype: str
+        """
+        severity: Optional[str] = (self._record.get("database_specific") or {}).get("severity")
+        if not severity:
+            return self._severity_from_score
+
+        return severity.upper()
+
+    @property
+    def _severity_from_score(self) -> str:
+        """
+        Severity rating derived from the CVSS base score.
+        The ranges are the CVSS v3.1 and v4.0 qualitative severity rating scale.
+
+        :return: Severity rating, e.g. ``HIGH``. ``UNKNOWN`` if there is no score.
+        :rtype: str
+        """
+        score = self.score
+        if score is None:
+            LOG.warning("%s doesn't have a severity rating or a CVSS score, assuming %s.", self.id, SEVERITY_UNKNOWN)
+            return SEVERITY_UNKNOWN
+
+        if score >= 9.0:
+            return SEVERITY_CRITICAL
+        if score >= 7.0:
+            return SEVERITY_HIGH
+        if score >= 4.0:
+            return SEVERITY_MEDIUM
+        if score > 0:
+            return SEVERITY_LOW
+
+        return SEVERITY_UNKNOWN


### PR DESCRIPTION
## The bug

`ih-github scan` crashes with a `KeyError` as soon as osv-scanner reports a record that isn't a GitHub advisory ([example run](https://github.com/tinyfish-io/playground/actions/runs/31038756452/job/92417830292)):

```
File ".../cli/ih_github/cmd_scan/__init__.py", line 154, in _get_vulnerability_details
    "severity": vuln["database_specific"]["severity"],
KeyError: 'database_specific'
```

`database_specific` is a **GitHub Advisory Database** field. PYSEC records don't have it, and OSV reports the PYSEC record of a CVE *before* its GHSA twin, so the loop died on the very first entry. The markdown table was already built by then — so the job printed the report and then a traceback, exited on the traceback instead of exit code 1, and never published the pull request comment.

## The fix

Severity falls back to the CVSS score osv-scanner calculates per group of aliases — the number already printed in the CVSS column of the report — mapped onto the CVSS v3.1/v4.0 qualitative rating scale.

The fallback is exact, not an approximation. The PYSEC vectors for `aiohttp==3.14.1` compute to the same numbers osv-scanner publishes, and land on the same ratings as the paired GHSA records:

| record | vector computes to | `max_severity` | GHSA rating |
|---|---|---|---|
| PYSEC-2026-3545 | 7.1 → High | 7.1 | HIGH |
| PYSEC-2026-3546 | 6.3 → Medium | 6.3 | MODERATE |
| PYSEC-2026-3547 | 6.9 → Medium | 6.9 | MODERATE |

`MEDIUM` and `MODERATE` both already map to `--sla-medium`, so SLA dates are unaffected. Severity labels are now shared constants between the parser and the SLA map so that pairing can't silently drift.

## Structure

Report parsing moves out of the command into `infrahouse_toolkit.osv`:

| class | responsibility |
|---|---|
| `Package` | `name`, `version`, `ecosystem` of a scanned package |
| `Vulnerability` | `id`, `package`, `score`, `severity` of an OSV record |
| `ScanReport` | runs osv-scanner once (cached) and yields `Vulnerability` objects |

`cmd_scan` drops 49 lines and now reads `vuln.severity` / `vuln.package.name`.

One detail worth reviewing: with license scanning enabled, packages with no vulnerabilities appear with **neither** a `vulnerabilities` nor a `groups` key, so those are read with a default. Fields the schema guarantees (`package`, and its `name`/`version`/`ecosystem`) stay indexed, so a future format change fails loudly instead of silently reporting empty values.

## Verification

- `make lint` — 10.00/10
- Full suite — 332 passed, 4 skipped
- 26 new tests: the PYSEC path, `database_specific: null`, missing `groups`, the full severity scale, and scan-once caching
- Ran the actual command against the `aiohttp==3.14.1` repro: no crash, exit code 1 preserved, comment renders

## Known, not addressed here

The report emits **two sections per CVE** — one for the PYSEC record, one for the GHSA record — and the pair can print different labels for the same issue (`MEDIUM` from the score, `MODERATE` from the advisory). That duplication predates this change; the crash was simply hiding it. Collapsing to one section per alias group (with an `[[IgnoredVulns]]` entry per ID so suppression still works) is a contained follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
