### PR TITLE
feat: add ih-mysql query-audit for RDS slow query log capture

### DIFF
--- a/infrahouse_toolkit/aws/rds/__init__.py
+++ b/infrahouse_toolkit/aws/rds/__init__.py
@@ -1,0 +1,36 @@
+"""
+RDS helpers.
+
+Provides :class:`RDSMySQLInstance` and :class:`RDSParameterGroup` for reading and
+changing an RDS DB instance's configuration, :class:`SlowLogCapture` for
+running a bounded slow query log capture, and :class:`QueryDigest` for turning
+the result into a ranked query profile with ``pt-query-digest``.
+"""
+
+from infrahouse_toolkit.aws.rds.exceptions import (
+    QueryDigestError,
+    RDSError,
+    RDSInstanceNotFound,
+    RDSParameterError,
+    SlowLogCaptureError,
+)
+from infrahouse_toolkit.aws.rds.instance import RDSMySQLInstance
+from infrahouse_toolkit.aws.rds.parameter_group import RDSParameterGroup
+from infrahouse_toolkit.aws.rds.query_digest import QueryDigest
+from infrahouse_toolkit.aws.rds.slow_log_capture import (
+    CAPTURE_PARAMETERS,
+    SlowLogCapture,
+)
+
+__all__ = [
+    "CAPTURE_PARAMETERS",
+    "QueryDigest",
+    "QueryDigestError",
+    "RDSError",
+    "RDSMySQLInstance",
+    "RDSInstanceNotFound",
+    "RDSParameterError",
+    "RDSParameterGroup",
+    "SlowLogCapture",
+    "SlowLogCaptureError",
+]

--- a/infrahouse_toolkit/aws/rds/exceptions.py
+++ b/infrahouse_toolkit/aws/rds/exceptions.py
@@ -1,0 +1,23 @@
+"""RDS-specific exceptions."""
+
+from infrahouse_toolkit.aws.exceptions import IHAWSException
+
+
+class RDSError(IHAWSException):
+    """Generic RDS error."""
+
+
+class RDSInstanceNotFound(RDSError):
+    """A DB instance could not be found."""
+
+
+class RDSParameterError(RDSError):
+    """A DB parameter cannot be read or modified as requested."""
+
+
+class SlowLogCaptureError(RDSError):
+    """Error during a slow query log capture."""
+
+
+class QueryDigestError(RDSError):
+    """Error while running ``pt-query-digest``."""

--- a/infrahouse_toolkit/aws/rds/instance.py
+++ b/infrahouse_toolkit/aws/rds/instance.py
@@ -1,0 +1,413 @@
+"""
+RDS for MySQL DB instance.
+
+Provides :class:`RDSMySQLInstance`, which extends
+:class:`infrahouse_core.aws.RDSInstance` with the MySQL-specific reads a slow
+query log audit needs, plus two control-plane operations: waiting for a
+parameter change to land, and pulling log files off the instance.
+"""
+
+import time
+from datetime import datetime, timedelta, timezone
+from logging import getLogger
+from os import path as osp
+from typing import List, Optional
+
+import boto3
+import requests
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.exceptions import ClientError
+from infrahouse_core.aws import RDSInstance, get_client
+
+from infrahouse_toolkit import DEFAULT_OPEN_ENCODING
+from infrahouse_toolkit.aws.rds.exceptions import RDSError, RDSInstanceNotFound
+from infrahouse_toolkit.aws.rds.parameter_group import RDSParameterGroup
+
+LOG = getLogger(__name__)
+
+
+class RDSMySQLInstance(RDSInstance):
+    """
+    An RDS for MySQL DB instance.
+
+    Inherits ``exists``, ``delete()``, ``db_instance_id`` and the lazy boto3
+    client from :class:`infrahouse_core.aws.RDSInstance`.
+
+    :param db_instance_id: DB instance identifier.
+    :type db_instance_id: str
+    :param region: AWS region.
+    :type region: str
+    :param role_arn: IAM role ARN for cross-account access.
+    :type role_arn: str
+    :param session: Pre-configured boto3 session.
+    :type session: Session
+    """
+
+    def __init__(self, db_instance_id: str, region: str = None, role_arn: str = None, session=None) -> None:
+        super().__init__(db_instance_id, region=region, role_arn=role_arn, session=session)
+        self._description: Optional[dict] = None
+        self._parameter_group: Optional[RDSParameterGroup] = None
+        self._cloudwatch_client = None
+
+    # --- Public properties ---
+
+    @property
+    def allocated_storage_bytes(self) -> int:
+        """
+        :return: Provisioned storage in bytes.
+        :rtype: int
+        """
+        return self.description["AllocatedStorage"] * 1024**3
+
+    @property
+    def cloudwatch_log_exports(self) -> List[str]:
+        """
+        Log types this instance publishes to CloudWatch Logs.
+
+        Note that ``slowquery`` appearing here does not mean anything is being
+        published — RDS ships the log *file*, so with ``log_output=TABLE`` the
+        export is configured but silent.
+
+        :return: Enabled CloudWatch Logs exports.
+        :rtype: List[str]
+        """
+        return self.description.get("EnabledCloudwatchLogsExports", [])
+
+    @property
+    def description(self) -> dict:
+        """
+        :return: Raw ``describe_db_instances`` entry for this instance.
+        :rtype: dict
+        :raises RDSInstanceNotFound: If the instance does not exist.
+        :raises ClientError: On any other RDS API failure.
+        """
+        if self._description is None:
+            try:
+                response = self._client.describe_db_instances(DBInstanceIdentifier=self._resource_id)
+            except ClientError as err:
+                if err.response["Error"]["Code"] == "DBInstanceNotFound":
+                    raise RDSInstanceNotFound(f"DB instance {self._resource_id} not found") from err
+                raise
+            self._description = response["DBInstances"][0]
+        return self._description
+
+    @property
+    def engine(self) -> str:
+        """
+        :return: Engine name, e.g. ``mysql``.
+        :rtype: str
+        """
+        return self.description["Engine"]
+
+    @property
+    def engine_version(self) -> str:
+        """
+        :return: Engine version, e.g. ``8.0.45``.
+        :rtype: str
+        """
+        return self.description["EngineVersion"]
+
+    @property
+    def free_storage_bytes(self) -> Optional[int]:
+        """
+        Most recent ``FreeStorageSpace`` reading from CloudWatch.
+
+        This is the metric that decides whether a capture is safe to run:
+        RDS keeps log files on the instance volume, so a long capture at
+        ``long_query_time=0`` eats the same space as the data.
+
+        :return: Free bytes, or ``None`` when CloudWatch has no recent
+            datapoint (the metric lags by a minute or two).
+        :rtype: Optional[int]
+        """
+        now = datetime.now(timezone.utc)
+        response = self._cloudwatch.get_metric_statistics(
+            Namespace="AWS/RDS",
+            MetricName="FreeStorageSpace",
+            Dimensions=[{"Name": "DBInstanceIdentifier", "Value": self._resource_id}],
+            StartTime=now - timedelta(minutes=15),
+            EndTime=now,
+            Period=60,
+            Statistics=["Minimum"],
+        )
+        datapoints = response["Datapoints"]
+        if not datapoints:
+            return None
+        latest = max(datapoints, key=lambda point: point["Timestamp"])
+        return int(latest["Minimum"])
+
+    @property
+    def parameter_apply_status(self) -> str:
+        """
+        :return: ``ParameterApplyStatus`` of the attached parameter group,
+            e.g. ``in-sync``, ``applying``, ``pending-reboot``.
+        :rtype: str
+        """
+        return self.description["DBParameterGroups"][0]["ParameterApplyStatus"]
+
+    @property
+    def parameter_group(self) -> RDSParameterGroup:
+        """
+        :return: The parameter group attached to this instance.
+        :rtype: RDSParameterGroup
+        """
+        if self._parameter_group is None:
+            name = self.description["DBParameterGroups"][0]["DBParameterGroupName"]
+            self._parameter_group = RDSParameterGroup(
+                name, region=self._region, role_arn=self._role_arn, session=self._session
+            )
+        return self._parameter_group
+
+    @property
+    def performance_insights_enabled(self) -> bool:
+        """
+        :return: Whether Performance Insights is enabled.
+        :rtype: bool
+        """
+        return bool(self.description.get("PerformanceInsightsEnabled"))
+
+    @property
+    def slow_log_files(self) -> List[dict]:
+        """
+        Slow query log files currently on the instance.
+
+        RDS rotates ``slowquery/mysql-slowquery.log`` hourly, so a capture
+        longer than an hour spans several files.
+
+        :return: Entries with ``name``, ``size`` and ``last_written``
+            (epoch milliseconds), newest last.
+        :rtype: List[dict]
+        """
+        files = []
+        paginator = self._client.get_paginator("describe_db_log_files")
+        for page in paginator.paginate(DBInstanceIdentifier=self._resource_id, FilenameContains="slowquery"):
+            for entry in page.get("DescribeDBLogFiles", []):
+                files.append(
+                    {
+                        "name": entry["LogFileName"],
+                        "size": entry["Size"],
+                        "last_written": entry["LastWritten"],
+                    }
+                )
+        return sorted(files, key=lambda entry: entry["last_written"])
+
+    @property
+    def slow_log_size(self) -> int:
+        """
+        :return: Combined size in bytes of all slow query log files on the instance.
+        :rtype: int
+        """
+        return sum(entry["size"] for entry in self.slow_log_files)
+
+    @property
+    def status(self) -> str:
+        """
+        :return: DB instance status, e.g. ``available``.
+        :rtype: str
+        """
+        return self.description["DBInstanceStatus"]
+
+    @property
+    def tags(self) -> dict:
+        """
+        :return: A dictionary with the DB instance tags.
+        :rtype: dict
+        """
+        return {tag["Key"]: tag["Value"] for tag in self.description.get("TagList", [])}
+
+    # --- Public methods ---
+
+    def download_log_file(self, log_file_name: str, destination_dir: str) -> str:
+        """
+        Download one RDS log file to a local directory.
+
+        Prefers the ``downloadCompleteLogFile`` REST endpoint, which streams the
+        whole file in a single signed request.  Falls back to the paginated
+        ``DownloadDBLogFilePortion`` API, which is correct but returns roughly a
+        megabyte per call and is throttled — painful for a capture of any size.
+
+        :param log_file_name: Log file name as reported by :attr:`slow_log_files`.
+        :type log_file_name: str
+        :param destination_dir: Local directory to write into.
+        :type destination_dir: str
+        :return: Path of the downloaded file.
+        :rtype: str
+        :raises RDSError: If the file cannot be downloaded.
+        """
+        destination = osp.join(destination_dir, log_file_name.replace("/", "-"))
+        try:
+            self._download_complete(log_file_name, destination)
+        except requests.RequestException as err:
+            LOG.warning("Streaming download of %s failed (%s), falling back to the portion API", log_file_name, err)
+            self._download_portions(log_file_name, destination)
+        LOG.info("Downloaded %s to %s", log_file_name, destination)
+        return destination
+
+    @classmethod
+    def list_instances(
+        cls,
+        engine_prefix: str = "mysql",
+        region: str = None,
+        role_arn: str = None,
+        session=None,
+    ) -> List["RDSMySQLInstance"]:
+        """
+        List DB instances, by default only the MySQL ones.
+
+        Each returned instance carries the description it was built from, so
+        reading its engine, status or tags costs no extra API call.
+
+        :param engine_prefix: Only return instances whose engine starts with
+            this.  Pass an empty string for every engine.
+        :type engine_prefix: str
+        :param region: AWS region.
+        :type region: str
+        :param role_arn: IAM role ARN for cross-account access.
+        :type role_arn: str
+        :param session: Pre-configured boto3 session.
+        :type session: Session
+        :return: Matching instances, ordered by identifier.
+        :rtype: List[RDSMySQLInstance]
+        """
+        if session is not None:
+            client = session.client("rds", region_name=region)
+        else:
+            client = get_client("rds", region=region, role_arn=role_arn)
+
+        instances = []
+        for page in client.get_paginator("describe_db_instances").paginate():
+            for description in page["DBInstances"]:
+                if not description["Engine"].startswith(engine_prefix):
+                    continue
+                instance = cls(
+                    description["DBInstanceIdentifier"],
+                    region=region,
+                    role_arn=role_arn,
+                    session=session,
+                )
+                instance.seed_description(description)
+                instances.append(instance)
+        return sorted(instances, key=lambda entry: entry.db_instance_id)
+
+    def refresh(self) -> None:
+        """Drop cached instance state so the next read hits the API."""
+        self._description = None
+
+    def seed_description(self, description: dict) -> None:
+        """
+        Populate the cached description from an already-fetched payload.
+
+        Lets a bulk ``describe_db_instances`` serve many instances without each
+        of them making the call again.
+
+        :param description: A ``DBInstances`` entry.
+        :type description: dict
+        """
+        self._description = description
+
+    def wait_parameters_in_sync(self, timeout: int = 600, poll_interval: int = 10, settle: int = 15) -> None:
+        """
+        Wait until the attached parameter group reports ``in-sync``.
+
+        A short *settle* delay comes first because RDS needs a moment to move
+        the status to ``applying``: polling immediately can observe the
+        pre-change ``in-sync`` and return before anything has happened.
+
+        :param timeout: Maximum seconds to wait.
+        :type timeout: int
+        :param poll_interval: Seconds between polls.
+        :type poll_interval: int
+        :param settle: Seconds to wait before the first poll.
+        :type settle: int
+        :raises RDSError: If the status becomes ``failed-to-apply`` or the
+            timeout is exceeded.
+        """
+        time.sleep(settle)
+        deadline = time.monotonic() + timeout
+        while True:
+            self.refresh()
+            status = self.parameter_apply_status
+            if status == "in-sync":
+                LOG.info("Parameter group %s is in-sync", self.parameter_group.name)
+                return
+            if status == "failed-to-apply":
+                raise RDSError(f"Parameter group {self.parameter_group.name} failed to apply")
+            LOG.info("Parameter group %s status is %s, waiting", self.parameter_group.name, status)
+            if time.monotonic() >= deadline:
+                raise RDSError(
+                    f"Parameter group {self.parameter_group.name} did not reach in-sync "
+                    f"within {timeout}s (last status {status})"
+                )
+            time.sleep(poll_interval)
+
+    # --- Private properties ---
+
+    @property
+    def _cloudwatch(self):
+        """
+        Lazy-loaded CloudWatch client, built the same way as the inherited RDS one.
+
+        :return: A boto3 CloudWatch client.
+        """
+        if self._cloudwatch_client is None:
+            if self._session is not None:
+                self._cloudwatch_client = self._session.client("cloudwatch", region_name=self._region)
+            else:
+                self._cloudwatch_client = get_client("cloudwatch", region=self._region, role_arn=self._role_arn)
+        return self._cloudwatch_client
+
+    # --- Private methods ---
+
+    def _download_complete(self, log_file_name: str, destination: str) -> None:
+        """
+        Download a log file through the ``downloadCompleteLogFile`` REST endpoint.
+
+        boto3 does not expose this endpoint, so the request is signed by hand
+        with SigV4.
+
+        :param log_file_name: Log file name.
+        :type log_file_name: str
+        :param destination: Local path to write to.
+        :type destination: str
+        :raises RDSError: If the session carries no credentials.
+        :raises requests.RequestException: On any HTTP-level failure.
+        """
+        session = self._session or boto3.Session(region_name=self._region)
+        credentials = session.get_credentials()
+        if credentials is None:
+            raise RDSError("No AWS credentials available to sign the log download request")
+
+        region = self._client.meta.region_name
+        url = f"https://rds.{region}.amazonaws.com/v13/downloadCompleteLogFile/{self._resource_id}/{log_file_name}"
+        request = AWSRequest(method="GET", url=url)
+        SigV4Auth(credentials.get_frozen_credentials(), "rds", region).add_auth(request)
+
+        with requests.get(url, headers=dict(request.headers), stream=True, timeout=(10, 900)) as response:
+            response.raise_for_status()
+            with open(destination, "wb") as descriptor:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    descriptor.write(chunk)
+
+    def _download_portions(self, log_file_name: str, destination: str) -> None:
+        """
+        Download a log file through the paginated ``DownloadDBLogFilePortion`` API.
+
+        :param log_file_name: Log file name.
+        :type log_file_name: str
+        :param destination: Local path to write to.
+        :type destination: str
+        """
+        marker = "0"
+        with open(destination, "w", encoding=DEFAULT_OPEN_ENCODING) as descriptor:
+            while True:
+                response = self._client.download_db_log_file_portion(
+                    DBInstanceIdentifier=self._resource_id,
+                    LogFileName=log_file_name,
+                    Marker=marker,
+                )
+                if response.get("LogFileData"):
+                    descriptor.write(response["LogFileData"])
+                if not response.get("AdditionalDataPending"):
+                    return
+                marker = response["Marker"]

--- a/infrahouse_toolkit/aws/rds/instance.py
+++ b/infrahouse_toolkit/aws/rds/instance.py
@@ -138,6 +138,21 @@ class RDSMySQLInstance(RDSInstance):
         return int(latest["Minimum"])
 
     @property
+    def max_allocated_storage_bytes(self) -> Optional[int]:
+        """
+        The ceiling storage autoscaling may grow this volume to.
+
+        Reported for context only.  A capture sizes its limits against
+        :attr:`allocated_storage_bytes`, because provoking an autoextend is
+        what it is trying to avoid, not a resource it may draw on.
+
+        :return: Bytes, or ``None`` when storage autoscaling is disabled.
+        :rtype: Optional[int]
+        """
+        ceiling = self.description.get("MaxAllocatedStorage")
+        return ceiling * 1024**3 if ceiling else None
+
+    @property
     def parameter_apply_status(self) -> str:
         """
         :return: ``ParameterApplyStatus`` of the attached parameter group,

--- a/infrahouse_toolkit/aws/rds/parameter_group.py
+++ b/infrahouse_toolkit/aws/rds/parameter_group.py
@@ -1,0 +1,297 @@
+"""
+RDS DB parameter group.
+
+Provides :class:`RDSParameterGroup` — a thin, read-mostly view over an RDS DB
+parameter group with the ability to apply and roll back a set of dynamic
+parameters.
+
+Parameter groups are the only way to change server variables on RDS: the master
+user normally lacks ``SYSTEM_VARIABLES_ADMIN``, so ``SET GLOBAL`` is unavailable,
+and even where it works RDS re-applies parameter group values behind you.
+"""
+
+from logging import getLogger
+from typing import Dict, List, Optional
+
+from botocore.exceptions import ClientError
+from infrahouse_core.aws.base import AWSResource
+
+from infrahouse_toolkit.aws.rds.exceptions import RDSParameterError
+
+LOG = getLogger(__name__)
+
+
+class RDSParameterGroup(AWSResource):
+    """
+    An RDS DB parameter group.
+
+    :param name: DB parameter group name.
+    :type name: str
+    :param region: AWS region.
+    :type region: str
+    :param role_arn: IAM role ARN for cross-account access.
+    :type role_arn: str
+    :param session: Pre-configured boto3 session.
+    :type session: Session
+    """
+
+    def __init__(self, name: str, region: str = None, role_arn: str = None, session=None) -> None:
+        super().__init__(name, "rds", region=region, role_arn=role_arn, session=session)
+        self._description: Optional[dict] = None
+        self._parameters: Optional[Dict[str, dict]] = None
+
+    # --- Public properties ---
+
+    @property
+    def attached_instance_ids(self) -> List[str]:
+        """
+        Identifiers of every DB instance using this parameter group.
+
+        Modifying a parameter group affects *all* of them.  Attaching a
+        different parameter group instead is not a way around that — it
+        requires a reboot even when the parameters themselves are dynamic.
+
+        :return: DB instance identifiers.
+        :rtype: List[str]
+        """
+        identifiers = []
+        for page in self._client.get_paginator("describe_db_instances").paginate():
+            for instance in page["DBInstances"]:
+                names = [group["DBParameterGroupName"] for group in instance.get("DBParameterGroups", [])]
+                if self._resource_id in names:
+                    identifiers.append(instance["DBInstanceIdentifier"])
+        return identifiers
+
+    @property
+    def description(self) -> dict:
+        """
+        :return: Raw ``describe_db_parameter_groups`` entry for this group.
+        :rtype: dict
+        :raises RDSParameterError: If the group does not exist.
+        """
+        if self._description is None:
+            response = self._client.describe_db_parameter_groups(DBParameterGroupName=self._resource_id)
+            groups = response["DBParameterGroups"]
+            if not groups:
+                raise RDSParameterError(f"DB parameter group {self._resource_id} not found")
+            self._description = groups[0]
+        return self._description
+
+    @property
+    def exists(self) -> bool:
+        """
+        :return: ``True`` if the parameter group exists.
+        :rtype: bool
+        :raises ClientError: On any RDS API failure other than "not found".
+        """
+        try:
+            self._client.describe_db_parameter_groups(DBParameterGroupName=self._resource_id)
+            return True
+        except ClientError as err:
+            if err.response["Error"]["Code"] == "DBParameterGroupNotFound":
+                return False
+            raise
+
+    @property
+    def family(self) -> str:
+        """
+        :return: Parameter group family, e.g. ``mysql8.0``.
+        :rtype: str
+        """
+        return self.description["DBParameterGroupFamily"]
+
+    @property
+    def is_default(self) -> bool:
+        """
+        Whether this is an RDS-provided default parameter group.
+
+        Default groups cannot be modified at all, so a capture that needs to
+        change parameters must target an instance on a custom group.
+
+        :return: ``True`` for a default group.
+        :rtype: bool
+        """
+        return self._resource_id.startswith("default.")
+
+    @property
+    def name(self) -> str:
+        """
+        :return: DB parameter group name.
+        :rtype: str
+        """
+        return self._resource_id
+
+    @property
+    def parameters(self) -> Dict[str, dict]:
+        """
+        Every parameter in the group, keyed by parameter name.
+
+        Includes engine defaults and RDS system values, not just the
+        user-modified ones, so callers can tell "unset, engine default"
+        apart from "explicitly set to the same value".
+
+        :return: Parameter name to its ``describe_db_parameters`` entry.
+        :rtype: Dict[str, dict]
+        """
+        if self._parameters is None:
+            parameters = {}
+            paginator = self._client.get_paginator("describe_db_parameters")
+            for page in paginator.paginate(DBParameterGroupName=self._resource_id):
+                for parameter in page["Parameters"]:
+                    parameters[parameter["ParameterName"]] = parameter
+            self._parameters = parameters
+        return self._parameters
+
+    # --- Public methods ---
+
+    def apply(self, values: Dict[str, str]) -> None:
+        """
+        Set parameters to the given values, effective immediately.
+
+        Every parameter is validated first: it must exist in this group's
+        family, be modifiable, and be dynamic.  A static parameter would only
+        take effect on reboot, which is never what a capture wants — so it is
+        rejected rather than silently queued.
+
+        :param values: Parameter name to desired value.
+        :type values: Dict[str, str]
+        :raises RDSParameterError: If the group is a default group, or any
+            parameter is unknown, read-only, or static.
+        """
+        if self.is_default:
+            raise RDSParameterError(
+                f"{self._resource_id} is a default parameter group and cannot be modified. "
+                f"Attach a custom parameter group to the instance first (this needs a reboot)."
+            )
+
+        self.validate_modifiable(list(values))
+
+        payload = [
+            {"ParameterName": name, "ParameterValue": str(value), "ApplyMethod": "immediate"}
+            for name, value in values.items()
+        ]
+        LOG.info("Applying to parameter group %s: %s", self._resource_id, values)
+        self._client.modify_db_parameter_group(DBParameterGroupName=self._resource_id, Parameters=payload)
+        self.refresh()
+
+    def delete(self) -> None:
+        """
+        Delete the parameter group.
+
+        Idempotent — does nothing if it does not exist.  Note RDS refuses to
+        delete a group that is still attached to an instance.
+
+        :raises ClientError: On any RDS API failure other than "not found".
+        """
+        try:
+            self._client.delete_db_parameter_group(DBParameterGroupName=self._resource_id)
+            LOG.info("Deleted DB parameter group %s", self._resource_id)
+        except ClientError as err:
+            if err.response["Error"]["Code"] == "DBParameterGroupNotFound":
+                LOG.info("DB parameter group %s does not exist.", self._resource_id)
+            else:
+                raise
+
+    def refresh(self) -> None:
+        """Drop cached parameter group state so the next read hits the API."""
+        self._description = None
+        self._parameters = None
+
+    def restore(self, snapshot: List[dict]) -> None:
+        """
+        Roll the group back to a snapshot taken by :meth:`snapshot`.
+
+        Parameters that were explicitly set by a user before the change are set
+        back to their previous value.  Parameters that were *not* user-set are
+        reset instead of being written with the default value — writing the
+        default would leave the group permanently marked as user-modified and
+        pinned against future RDS default changes.
+
+        :param snapshot: Output of :meth:`snapshot`.
+        :type snapshot: List[dict]
+        """
+        to_set = {entry["name"]: entry["value"] for entry in snapshot if entry["source"] == "user"}
+        to_reset = [entry["name"] for entry in snapshot if entry["source"] != "user"]
+
+        if to_set:
+            payload = [
+                {"ParameterName": name, "ParameterValue": str(value), "ApplyMethod": "immediate"}
+                for name, value in to_set.items()
+            ]
+            LOG.info("Restoring user values in %s: %s", self._resource_id, to_set)
+            self._client.modify_db_parameter_group(DBParameterGroupName=self._resource_id, Parameters=payload)
+
+        if to_reset:
+            payload = [{"ParameterName": name, "ApplyMethod": "immediate"} for name in to_reset]
+            LOG.info("Resetting to engine defaults in %s: %s", self._resource_id, ", ".join(to_reset))
+            self._client.reset_db_parameter_group(DBParameterGroupName=self._resource_id, Parameters=payload)
+
+        self.refresh()
+
+    def snapshot(self, names: List[str]) -> List[dict]:
+        """
+        Record the current value and origin of the named parameters.
+
+        The origin matters as much as the value: ``source`` is ``user`` when
+        somebody set the parameter explicitly, and ``engine-default`` or
+        ``system`` when the value is merely inherited.  :meth:`restore` uses
+        that distinction to decide between setting and resetting.
+
+        :param names: Parameter names to record.
+        :type names: List[str]
+        :return: One entry per parameter with ``name``, ``value`` and ``source``.
+        :rtype: List[dict]
+        :raises RDSParameterError: If a parameter does not exist in this family.
+        """
+        recorded = []
+        for name in names:
+            parameter = self.parameters.get(name)
+            if parameter is None:
+                raise RDSParameterError(f"Parameter {name} does not exist in family {self.family}")
+            recorded.append(
+                {
+                    "name": name,
+                    "value": parameter.get("ParameterValue"),
+                    "source": parameter.get("Source"),
+                }
+            )
+        return recorded
+
+    def validate_modifiable(self, names: List[str]) -> None:
+        """
+        Ensure the named parameters can all be changed immediately.
+
+        Checking against the group's own family is what makes this work
+        unchanged across engine versions: MySQL 8.0 and 8.4 do not expose the
+        same set of parameters, and an unknown name fails here with a clear
+        message instead of being silently dropped.
+
+        :param names: Parameter names to check.
+        :type names: List[str]
+        :raises RDSParameterError: If any parameter is unknown, read-only, or static.
+        """
+        for name in names:
+            parameter = self.parameters.get(name)
+            if parameter is None:
+                raise RDSParameterError(
+                    f"Parameter {name} does not exist in family {self.family}. "
+                    f"Engine versions differ in which parameters they expose."
+                )
+            if not parameter.get("IsModifiable"):
+                raise RDSParameterError(f"Parameter {name} is not modifiable on RDS (IsModifiable=false)")
+            if parameter.get("ApplyType") != "dynamic":
+                raise RDSParameterError(
+                    f"Parameter {name} is {parameter.get('ApplyType')}, not dynamic — "
+                    f"changing it would require a reboot"
+                )
+
+    def value_of(self, name: str) -> Optional[str]:
+        """
+        :param name: Parameter name.
+        :type name: str
+        :return: The effective value, or ``None`` when the parameter is unset
+            and the engine picks the default at runtime.
+        :rtype: Optional[str]
+        """
+        parameter = self.parameters.get(name)
+        return parameter.get("ParameterValue") if parameter else None

--- a/infrahouse_toolkit/aws/rds/query_digest.py
+++ b/infrahouse_toolkit/aws/rds/query_digest.py
@@ -1,0 +1,156 @@
+"""
+``pt-query-digest`` wrapper.
+
+Provides :class:`QueryDigest`, which turns downloaded slow log files into a
+ranked query profile.  It lives next to the capture because the two are halves
+of the same job: the capture produces logs nobody can read, the digest turns
+them into an answer.
+"""
+
+from datetime import datetime
+from logging import getLogger
+from subprocess import CalledProcessError, run  # nosec B404
+from typing import List
+
+from infrahouse_toolkit import DEFAULT_OPEN_ENCODING
+from infrahouse_toolkit.aws.rds.exceptions import QueryDigestError
+
+LOG = getLogger(__name__)
+
+PT_QUERY_DIGEST = "pt-query-digest"
+
+
+class QueryDigest:
+    """
+    A ``pt-query-digest`` run over a set of slow log files.
+
+    :param log_files: Slow log files to digest.
+    :type log_files: List[str]
+    :param since: Ignore events before this time.  Pass the capture start when
+        digesting a log file that RDS had already been writing to, since the
+        whole file comes down and the earlier part is not part of the window.
+    :type since: datetime
+    :param until: Ignore events after this time.
+    :type until: datetime
+    """
+
+    def __init__(self, log_files: List[str], since: datetime = None, until: datetime = None) -> None:
+        self._log_files = log_files
+        self._since = since
+        self._until = until
+
+    # --- Public properties ---
+
+    @property
+    def log_files(self) -> List[str]:
+        """
+        :return: Slow log files being digested.
+        :rtype: List[str]
+        """
+        return self._log_files
+
+    # --- Public methods ---
+
+    def command(
+        self,
+        group_by: str = "fingerprint",
+        order_by: str = "Query_time:sum",
+        limit: str = "20",
+        query_filter: str = None,
+    ) -> List[str]:
+        """
+        Build the ``pt-query-digest`` command line.
+
+        :param group_by: What to aggregate on — ``fingerprint`` for individual
+            queries, ``tables`` for a per-table breakdown.
+        :type group_by: str
+        :param order_by: Ranking attribute, e.g. ``Query_time:sum`` or
+            ``Rows_examined:sum``.
+        :type order_by: str
+        :param limit: How many classes to report, in ``pt-query-digest``
+            syntax (``20``, ``95%:20``, ...).
+        :type limit: str
+        :param query_filter: Perl expression passed to ``--filter``, e.g.
+            ``$event->{arg} =~ m/fetch_results/``.
+        :type query_filter: str
+        :return: Command line as a list.
+        :rtype: List[str]
+        :raises QueryDigestError: If there are no log files to digest.
+        """
+        if not self._log_files:
+            raise QueryDigestError("No slow log files to digest")
+
+        command = [
+            PT_QUERY_DIGEST,
+            "--group-by",
+            group_by,
+            "--order-by",
+            order_by,
+            "--limit",
+            limit,
+        ]
+        if self._since:
+            command += ["--since", self._format_time(self._since)]
+        if self._until:
+            command += ["--until", self._format_time(self._until)]
+        if query_filter:
+            command += ["--filter", query_filter]
+        return command + self._log_files
+
+    def report(  # pylint: disable=too-many-arguments
+        self,
+        output_path: str,
+        group_by: str = "fingerprint",
+        order_by: str = "Query_time:sum",
+        limit: str = "20",
+        query_filter: str = None,
+    ) -> str:
+        """
+        Run ``pt-query-digest`` and write its report to a file.
+
+        :param output_path: Where to write the report.
+        :type output_path: str
+        :param group_by: See :meth:`command`.
+        :type group_by: str
+        :param order_by: See :meth:`command`.
+        :type order_by: str
+        :param limit: See :meth:`command`.
+        :type limit: str
+        :param query_filter: See :meth:`command`.
+        :type query_filter: str
+        :return: *output_path*.
+        :rtype: str
+        :raises QueryDigestError: If ``pt-query-digest`` is missing or fails.
+        """
+        command = self.command(group_by=group_by, order_by=order_by, limit=limit, query_filter=query_filter)
+        LOG.info("Running: %s", " ".join(command))
+        try:
+            result = run(command, capture_output=True, check=True, encoding=DEFAULT_OPEN_ENCODING)  # nosec B603
+        except FileNotFoundError as err:
+            raise QueryDigestError(
+                f"{PT_QUERY_DIGEST} is not installed. Install percona-toolkit "
+                f"(apt-get install percona-toolkit / brew install percona-toolkit)."
+            ) from err
+        except CalledProcessError as err:
+            raise QueryDigestError(f"{PT_QUERY_DIGEST} exited with {err.returncode}: {err.stderr}") from err
+
+        with open(output_path, "w", encoding=DEFAULT_OPEN_ENCODING) as descriptor:
+            descriptor.write(result.stdout)
+        LOG.info("Wrote %s", output_path)
+        return output_path
+
+    # --- Private methods ---
+
+    @staticmethod
+    def _format_time(moment: datetime) -> str:
+        """
+        Format a timestamp the way ``pt-query-digest`` expects.
+
+        RDS writes slow log timestamps in UTC, so *moment* must be UTC too.
+
+        :param moment: Timestamp to format.
+        :type moment: datetime
+        :return: ``YYYY-MM-DD HH:MM:SS``.
+        :rtype: str
+        """
+        return moment.strftime("%Y-%m-%d %H:%M:%S")

--- a/infrahouse_toolkit/aws/rds/query_digest.py
+++ b/infrahouse_toolkit/aws/rds/query_digest.py
@@ -42,6 +42,25 @@ class QueryDigest:
     # --- Public properties ---
 
     @property
+    def event_count(self) -> int:
+        """
+        How many query events the log files actually contain.
+
+        Not the same as "the files are non-empty": MySQL writes a few hundred
+        bytes of preamble when it creates the slow log, so a capture that logged
+        nothing at all still produces a file.  Counting ``# Query_time:`` lines
+        is what distinguishes a real capture from an empty one.
+
+        :return: Number of logged queries across all log files.
+        :rtype: int
+        """
+        count = 0
+        for path in self._log_files:
+            with open(path, encoding=DEFAULT_OPEN_ENCODING, errors="replace") as descriptor:
+                count += sum(1 for line in descriptor if line.startswith("# Query_time:"))
+        return count
+
+    @property
     def log_files(self) -> List[str]:
         """
         :return: Slow log files being digested.

--- a/infrahouse_toolkit/aws/rds/slow_log_capture.py
+++ b/infrahouse_toolkit/aws/rds/slow_log_capture.py
@@ -1,0 +1,491 @@
+"""
+Temporary slow query log capture on an RDS MySQL instance.
+
+Provides :class:`SlowLogCapture` — a context manager that turns the slow query
+log all the way up for a bounded window, watches the instance while it fills,
+and puts every parameter back the way it found it.
+
+This is the RDS port of the long-standing "collect a slow log for an hour"
+shell script.  Two mechanisms change on RDS:
+
+* there is no ``SET GLOBAL`` and no writable ``slow_query_log_file``, so
+  everything goes through the DB parameter group;
+* ``log_output`` defaults to ``TABLE``, which produces no log file at all, so
+  the capture has to flip it to ``FILE`` — and ``log_slow_extra`` only has an
+  effect once it does.
+"""
+
+import json
+import os
+import signal
+import time
+from datetime import datetime, timezone
+from logging import getLogger
+from typing import Dict, List, Optional
+
+from boto3.session import Session
+from botocore.exceptions import ClientError
+
+from infrahouse_toolkit import DEFAULT_OPEN_ENCODING
+from infrahouse_toolkit.aws.rds.exceptions import RDSError, SlowLogCaptureError
+from infrahouse_toolkit.aws.rds.instance import RDSMySQLInstance
+from infrahouse_toolkit.aws.rds.parameter_group import RDSParameterGroup
+
+LOG = getLogger(__name__)
+
+# Every parameter the capture touches, and therefore every parameter it must
+# record beforehand and put back afterwards.
+CAPTURE_PARAMETERS = [
+    "log_output",
+    "slow_query_log",
+    "long_query_time",
+    "log_slow_extra",
+    "log_slow_admin_statements",
+]
+
+
+class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
+    """
+    A bounded slow query log capture on an RDS MySQL instance.
+
+    Used as a context manager::
+
+        with SlowLogCapture(instance) as capture:
+            capture.watch(max_run_time=3600, max_log_size=1024**3, min_free_storage=20 * 1024**3)
+            paths = capture.download("./audit")
+
+    Leaving the block restores every parameter, whether the block finished,
+    raised, or was interrupted.
+
+    :param instance: The instance to capture on.
+    :type instance: RDSMySQLInstance
+    :param long_query_time: Threshold to log at.  ``0`` logs everything, which
+        is the point — a nonzero threshold hides the cheap, frequent queries.
+    :type long_query_time: float
+    :param log_slow_extra: Whether to record the extra per-query attributes
+        (``Rows_examined``, ``Read_*``, ``Tmp_tables``, ...).
+    :type log_slow_extra: bool
+    :param log_slow_admin_statements: Whether to log admin statements such as
+        ``ALTER TABLE``.
+    :type log_slow_admin_statements: bool
+    :param state_file: Where to record the pre-capture parameter values.
+    :type state_file: str
+    :param allow_shared_parameter_group: Proceed even when the parameter group
+        is attached to more than one instance.
+    :type allow_shared_parameter_group: bool
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        instance: RDSMySQLInstance,
+        long_query_time: float = 0,
+        log_slow_extra: bool = True,
+        log_slow_admin_statements: bool = True,
+        state_file: str = None,
+        allow_shared_parameter_group: bool = False,
+    ) -> None:
+        self._instance = instance
+        self._long_query_time = long_query_time
+        self._log_slow_extra = log_slow_extra
+        self._log_slow_admin_statements = log_slow_admin_statements
+        self._state_file = state_file or f"ih-query-audit-{instance.db_instance_id}.state.json"
+        self._allow_shared_parameter_group = allow_shared_parameter_group
+        self._snapshot: Optional[List[dict]] = None
+        self._baseline: Dict[str, int] = {}
+        self._started_at: Optional[datetime] = None
+        self._previous_sigterm_handler = None
+
+    def __enter__(self) -> "SlowLogCapture":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        self.stop()
+        return False
+
+    # --- Public properties ---
+
+    @property
+    def captured_bytes(self) -> int:
+        """
+        Slow log bytes written since the capture started.
+
+        Measured against a baseline taken at :meth:`start`, so log files that
+        were already on the instance do not count toward the size limit.
+
+        :return: Bytes written since the capture started.
+        :rtype: int
+        """
+        total = 0
+        for entry in self._instance.slow_log_files:
+            total += max(0, entry["size"] - self._baseline.get(entry["name"], 0))
+        return total
+
+    @property
+    def desired_parameters(self) -> Dict[str, str]:
+        """
+        The parameter values this capture will apply.
+
+        :return: Parameter name to value.
+        :rtype: Dict[str, str]
+        """
+        return {
+            # RDS defaults log_output to TABLE, which writes to mysql.slow_log
+            # instead of a file.  pt-query-digest cannot read that, CloudWatch
+            # exports stay silent, and log_slow_extra has no effect there.
+            "log_output": "FILE",
+            "slow_query_log": "1",
+            "long_query_time": str(self._long_query_time),
+            "log_slow_extra": "ON" if self._log_slow_extra else "OFF",
+            "log_slow_admin_statements": "1" if self._log_slow_admin_statements else "0",
+        }
+
+    @property
+    def instance(self) -> RDSMySQLInstance:
+        """
+        :return: The instance being captured on.
+        :rtype: RDSMySQLInstance
+        """
+        return self._instance
+
+    @property
+    def started_at(self) -> Optional[datetime]:
+        """
+        :return: When the capture started (UTC), or ``None`` before :meth:`start`.
+        :rtype: Optional[datetime]
+        """
+        return self._started_at
+
+    @property
+    def state(self) -> dict:
+        """
+        The payload written to the state file.
+
+        :return: Everything needed to undo the capture from a cold start.
+        :rtype: dict
+        :raises SlowLogCaptureError: If called before :meth:`start`.
+        """
+        if self._snapshot is None or self._started_at is None:
+            raise SlowLogCaptureError("Capture has not started, there is no state to record")
+        return {
+            "instance_id": self._instance.db_instance_id,
+            "parameter_group": self._instance.parameter_group.name,
+            "started_at": self._started_at.isoformat(),
+            "parameters": self._snapshot,
+        }
+
+    @property
+    def state_file(self) -> str:
+        """
+        :return: Path of the file recording pre-capture parameter values.
+        :rtype: str
+        """
+        return self._state_file
+
+    # --- Public methods ---
+
+    def download(self, destination_dir: str) -> List[str]:
+        """
+        Download every slow log file this capture wrote to.
+
+        Files that grew during the capture are downloaded whole — RDS has no
+        way to fetch a byte range — so the returned files may contain queries
+        from before the window.  Filter those out downstream with
+        ``pt-query-digest --since``, using :attr:`started_at`.
+
+        :param destination_dir: Local directory to write into.
+        :type destination_dir: str
+        :return: Paths of the downloaded files.
+        :rtype: List[str]
+        """
+        os.makedirs(destination_dir, exist_ok=True)
+        paths = []
+        for entry in self._instance.slow_log_files:
+            if entry["size"] <= self._baseline.get(entry["name"], 0):
+                continue
+            paths.append(self._instance.download_log_file(entry["name"], destination_dir))
+        if not paths:
+            LOG.warning("No slow log data was written during the capture window")
+        return paths
+
+    def preflight(self, max_log_size: int = 0, min_free_storage: int = 0) -> None:
+        """
+        Check that the capture is safe to run before anything is modified.
+
+        :param max_log_size: Log bytes the capture is allowed to write.
+        :type max_log_size: int
+        :param min_free_storage: Free bytes that must remain available.
+        :type min_free_storage: int
+        :raises SlowLogCaptureError: If the instance, its parameter group, or
+            its free storage make the capture unsafe.
+        :raises RDSParameterError: If a parameter cannot be changed immediately.
+        """
+        if not self._instance.engine.startswith("mysql"):
+            raise SlowLogCaptureError(
+                f"{self._instance.db_instance_id} runs {self._instance.engine}; this capture supports RDS for MySQL"
+            )
+        if self._instance.status != "available":
+            raise SlowLogCaptureError(f"{self._instance.db_instance_id} is {self._instance.status}, expected available")
+
+        group = self._instance.parameter_group
+        if group.is_default:
+            raise SlowLogCaptureError(
+                f"{self._instance.db_instance_id} uses default parameter group {group.name}, which RDS does not "
+                f"allow modifying. Attach a custom parameter group first — that needs a reboot."
+            )
+
+        attached = group.attached_instance_ids
+        if len(attached) > 1 and not self._allow_shared_parameter_group:
+            raise SlowLogCaptureError(
+                f"Parameter group {group.name} is attached to {len(attached)} instances "
+                f"({', '.join(attached)}). Modifying it would turn the slow log up on all of them. "
+                f"Pass allow_shared_parameter_group to proceed anyway."
+            )
+
+        group.validate_modifiable(list(self.desired_parameters))
+
+        free = self._instance.free_storage_bytes
+        if free is None:
+            raise SlowLogCaptureError(
+                "CloudWatch has no recent FreeStorageSpace datapoint for "
+                f"{self._instance.db_instance_id}; refusing to fill a volume whose free space cannot be verified"
+            )
+        required = max_log_size + min_free_storage
+        if free < required:
+            raise SlowLogCaptureError(
+                f"{self._instance.db_instance_id} has {self._as_gib(free)} free, but the capture needs "
+                f"{self._as_gib(max_log_size)} of headroom on top of a {self._as_gib(min_free_storage)} reserve"
+            )
+        self._warn_about_cloudwatch_export()
+        LOG.info("Preflight passed: %s free on %s", self._as_gib(free), self._instance.db_instance_id)
+
+    def start(self) -> None:
+        """
+        Record current parameter values, then turn the slow log up.
+
+        The state file is written *before* anything is modified, so a capture
+        that dies between the two can still be undone.
+
+        A failure *after* the parameters land rolls itself back: ``__enter__``
+        raising means ``__exit__`` never runs, so nothing else would.
+
+        :raises RDSParameterError: If a parameter cannot be changed immediately.
+        :raises RDSError: If the change could not be confirmed as applied.
+        :raises ClientError: If an RDS API call failed.
+        """
+        group = self._instance.parameter_group
+        self._snapshot = group.snapshot(CAPTURE_PARAMETERS)
+        self._started_at = datetime.now(timezone.utc)
+        self._baseline = {entry["name"]: entry["size"] for entry in self._instance.slow_log_files}
+
+        self._write_state_file()
+        self._install_sigterm_handler()
+
+        LOG.info("Previous values: %s", {entry["name"]: entry["value"] for entry in self._snapshot})
+        try:
+            group.apply(self.desired_parameters)
+            self._instance.wait_parameters_in_sync()
+        except (ClientError, RDSError):
+            LOG.error("Could not start the capture on %s, rolling back", self._instance.db_instance_id)
+            self.stop()
+            raise
+        self._warn_about_open_connections()
+
+    def stop(self) -> None:
+        """
+        Put every parameter back and remove the state file.
+
+        On failure the state file is deliberately left in place so the capture
+        can be undone by hand — an instance left at ``long_query_time=0`` will
+        keep filling its volume.
+
+        :raises RDSError: If the parameters could not be restored.
+        :raises ClientError: If the RDS API call to restore them failed.
+        """
+        if self._snapshot is None:
+            return
+        try:
+            LOG.info("Restoring parameters on %s", self._instance.db_instance_id)
+            self._instance.parameter_group.restore(self._snapshot)
+            self._instance.wait_parameters_in_sync()
+        except (ClientError, RDSError) as err:
+            LOG.error("Failed to restore parameters: %s", err)
+            LOG.error("%s IS STILL CAPTURING. Undo it with:", self._instance.db_instance_id)
+            LOG.error("    ih-mysql query-audit restore --state-file %s", self._state_file)
+            raise
+        finally:
+            self._snapshot = None
+            self._restore_sigterm_handler()
+
+        self._remove_state_file()
+        LOG.info("Parameters restored on %s", self._instance.db_instance_id)
+
+    def watch(
+        self,
+        max_run_time: int,
+        max_log_size: int,
+        min_free_storage: int,
+        poll_interval: int = 30,
+    ) -> str:
+        """
+        Block until a stop condition is met.
+
+        Stops on whichever comes first: the time limit, the log size limit, or
+        free storage dropping to the reserve.  The storage check is the one
+        that matters — RDS log files share the data volume, and a full volume
+        takes the instance down.
+
+        :param max_run_time: Maximum capture duration in seconds.
+        :type max_run_time: int
+        :param max_log_size: Maximum slow log bytes to write.
+        :type max_log_size: int
+        :param min_free_storage: Stop if free storage drops below this many bytes.
+        :type min_free_storage: int
+        :param poll_interval: Seconds between checks.
+        :type poll_interval: int
+        :return: Which limit ended the capture.
+        :rtype: str
+        """
+        if self._started_at is None:
+            raise SlowLogCaptureError("Capture has not started, there is nothing to watch")
+
+        deadline = self._started_at.timestamp() + max_run_time
+        while True:
+            captured = self.captured_bytes
+            free = self._instance.free_storage_bytes
+            remaining = int(deadline - datetime.now(timezone.utc).timestamp())
+            LOG.info(
+                "Captured %s, %s free, %ds remaining",
+                self._as_gib(captured),
+                self._as_gib(free) if free is not None else "unknown",
+                max(0, remaining),
+            )
+
+            if captured >= max_log_size:
+                return f"log size limit reached ({self._as_gib(captured)})"
+            if free is not None and free <= min_free_storage:
+                return f"free storage dropped to {self._as_gib(free)}"
+            if remaining <= 0:
+                return f"time limit reached ({max_run_time}s)"
+
+            time.sleep(min(poll_interval, max(1, remaining)))
+
+    @classmethod
+    def restore_from_state_file(cls, state_file: str, session: Session) -> str:
+        """
+        Undo a capture from its state file, without the original process.
+
+        :param state_file: Path to the state file written by :meth:`start`.
+        :type state_file: str
+        :param session: Authenticated boto3 session.
+        :type session: Session
+        :return: Identifier of the instance that was restored.
+        :rtype: str
+        :raises SlowLogCaptureError: If the state file is unusable.
+        """
+        try:
+            with open(state_file, encoding=DEFAULT_OPEN_ENCODING) as descriptor:
+                state = json.load(descriptor)
+        except json.JSONDecodeError as err:
+            raise SlowLogCaptureError(f"{state_file} is not valid JSON: {err}") from err
+
+        try:
+            group_name = state["parameter_group"]
+            instance_id = state["instance_id"]
+            parameters = state["parameters"]
+        except KeyError as err:
+            raise SlowLogCaptureError(f"{state_file} is missing key {err}") from err
+
+        LOG.info("Restoring %s from %s", instance_id, state_file)
+        RDSParameterGroup(group_name, session=session).restore(parameters)
+        RDSMySQLInstance(instance_id, session=session).wait_parameters_in_sync()
+        os.remove(state_file)
+        return instance_id
+
+    # --- Private methods ---
+
+    @staticmethod
+    def _as_gib(size: int) -> str:
+        """
+        :param size: Size in bytes.
+        :type size: int
+        :return: Human-readable size.
+        :rtype: str
+        """
+        return f"{size / 1024 ** 3:.2f} GiB"
+
+    def _install_sigterm_handler(self) -> None:
+        """
+        Turn SIGTERM into SystemExit so the context manager still unwinds.
+
+        SIGINT already raises KeyboardInterrupt; SIGTERM would otherwise kill
+        the process with the instance still capturing.
+        """
+
+        def handler(signum, frame):  # pylint: disable=unused-argument
+            raise SystemExit(f"Received signal {signum}, stopping the capture")
+
+        self._previous_sigterm_handler = signal.signal(signal.SIGTERM, handler)
+
+    def _remove_state_file(self) -> None:
+        """Delete the state file once the capture has been undone."""
+        if os.path.exists(self._state_file):
+            os.remove(self._state_file)
+
+    def _restore_sigterm_handler(self) -> None:
+        """Put the previous SIGTERM handler back."""
+        if self._previous_sigterm_handler is not None:
+            signal.signal(signal.SIGTERM, self._previous_sigterm_handler)
+            self._previous_sigterm_handler = None
+
+    def _warn_about_cloudwatch_export(self) -> None:
+        """
+        Warn when flipping ``log_output`` will wake a dormant CloudWatch export.
+
+        RDS publishes the slow log *file*, so an instance configured with
+        ``slowquery`` in its exports but ``log_output=TABLE`` has been shipping
+        nothing.  Setting ``log_output=FILE`` starts that export for the
+        duration of the capture — a useful durable copy, and a billable one.
+        """
+        if "slowquery" not in self._instance.cloudwatch_log_exports:
+            return
+        if self._instance.parameter_group.value_of("log_output") == "FILE":
+            return
+        LOG.warning(
+            "slowquery is in EnabledCloudwatchLogsExports but log_output is not FILE, so nothing has been "
+            "published so far. This capture starts that export, and CloudWatch Logs ingestion is billable."
+        )
+
+    def _warn_about_open_connections(self) -> None:
+        """
+        Warn that connections opened before the change keep the old threshold.
+
+        ``long_query_time`` is a session variable seeded from the global value
+        at connect time.  Percona Server has ``use_global_long_query_time`` to
+        force existing sessions to pick up the new value; community MySQL, and
+        therefore RDS for MySQL, does not.  On a pooled application the capture
+        sees nothing from established connections until the pool recycles.
+        """
+        LOG.warning(
+            "Connections opened before this change keep their old long_query_time — "
+            "MySQL seeds it per session at connect time and has no equivalent of Percona's "
+            "use_global_long_query_time. Pooled clients will not appear until the pool recycles."
+        )
+        if self._instance.parameter_group.value_of("performance_schema") in ("0", None):
+            LOG.warning(
+                "performance_schema is off, so the number of sessions still on the old "
+                "threshold cannot be measured. Enabling it needs a reboot (it is a static parameter)."
+            )
+
+    def _write_state_file(self) -> None:
+        """
+        Persist pre-capture parameter values.
+
+        :raises SlowLogCaptureError: If the state file cannot be written.
+        """
+        try:
+            with open(self._state_file, "w", encoding=DEFAULT_OPEN_ENCODING) as descriptor:
+                json.dump(self.state, descriptor, indent=4)
+        except OSError as err:
+            raise SlowLogCaptureError(f"Cannot write state file {self._state_file}: {err}") from err
+        LOG.info("Recorded pre-capture parameters in %s", self._state_file)

--- a/infrahouse_toolkit/aws/rds/slow_log_capture.py
+++ b/infrahouse_toolkit/aws/rds/slow_log_capture.py
@@ -13,6 +13,28 @@ shell script.  Two mechanisms change on RDS:
 * ``log_output`` defaults to ``TABLE``, which produces no log file at all, so
   the capture has to flip it to ``FILE`` — and ``log_slow_extra`` only has an
   effect once it does.
+
+.. rubric:: Known limitation: capture coverage cannot be measured
+
+``long_query_time`` is a session variable seeded from the global value when a
+connection is made, so connections that predate the change keep the old
+threshold.  Percona Server has ``use_global_long_query_time`` to force existing
+sessions onto the new value; community MySQL, and therefore RDS for MySQL, does
+not.  A pooled client contributes nothing to the capture until its pool
+recycles.
+
+This capture cannot tell you how much of the workload that costs it.  It talks
+only to the RDS control plane and holds no MySQL credentials, so it cannot run
+SQL; and the one place a session's own ``long_query_time`` is visible,
+``performance_schema.variables_by_thread``, needs ``performance_schema``, which
+is off by default on RDS and static, so enabling it costs a reboot.
+
+The consequence is that an empty capture is ambiguous: an idle instance and a
+fully stale connection pool look identical from here.  To tell them apart by
+hand, sample ``SHOW GLOBAL STATUS`` before and after the window.  A ``Queries``
+delta near zero means the instance was idle.  A non-zero ``Queries`` delta with
+no movement in ``Slow_queries`` means the sessions never picked up the new
+threshold, and their ratio approximates how much of the traffic did.
 """
 
 import json
@@ -42,6 +64,27 @@ CAPTURE_PARAMETERS = [
     "log_slow_extra",
     "log_slow_admin_statements",
 ]
+
+# RDS starts a storage autoscaling event when free space falls below 10% of
+# allocated storage (sustained for five minutes, and no more than once every six
+# hours).  Autoscaling is not the non-event AWS describes it as, so the capture
+# treats that threshold as a floor it must never cross rather than a cushion it
+# may spend.  Keeping free space at or above 10% means the first of those three
+# conditions is never met.
+FREE_STORAGE_RESERVE_RATIO = 0.10
+
+# Ceiling on what one capture may write, so that even a full-size capture
+# starting at the reserve cannot push free space under it.  Both ratios are
+# taken against *current* allocated storage — the autoscale maximum is headroom
+# we are specifically refusing to use.
+MAX_LOG_SIZE_RATIO = 0.05
+
+# What a capture writes by default.  The ratio above is a safety ceiling, not a
+# working size: 5% of a 2 TiB volume is 100 GiB of slow log, which is a
+# download and a pt-query-digest run nobody asked for.  A gigabyte is already
+# far more than a query profile needs, and the ceiling still wins on small
+# volumes where 5% is less than this.
+DEFAULT_MAX_LOG_SIZE = 1024**3
 
 
 class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
@@ -92,6 +135,7 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
         self._allow_shared_parameter_group = allow_shared_parameter_group
         self._snapshot: Optional[List[dict]] = None
         self._baseline: Dict[str, int] = {}
+        self._initiated_at: Optional[datetime] = None
         self._started_at: Optional[datetime] = None
         self._previous_sigterm_handler = None
 
@@ -122,6 +166,31 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
         return total
 
     @property
+    def default_max_log_size(self) -> int:
+        """
+        What a capture writes unless told otherwise.
+
+        :data:`DEFAULT_MAX_LOG_SIZE`, or :attr:`max_log_size_ceiling` when the
+        volume is small enough that the safety ceiling is the lower of the two.
+
+        :return: Bytes.
+        :rtype: int
+        """
+        return min(DEFAULT_MAX_LOG_SIZE, self.max_log_size_ceiling)
+
+    @property
+    def default_min_free_storage(self) -> int:
+        """
+        Free space the capture must leave, as a share of current allocated storage.
+
+        This is RDS's own storage-autoscaling trigger point, not a round number.
+
+        :return: Bytes.
+        :rtype: int
+        """
+        return int(self._instance.allocated_storage_bytes * FREE_STORAGE_RESERVE_RATIO)
+
+    @property
     def desired_parameters(self) -> Dict[str, str]:
         """
         The parameter values this capture will apply.
@@ -135,7 +204,7 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
             # exports stay silent, and log_slow_extra has no effect there.
             "log_output": "FILE",
             "slow_query_log": "1",
-            "long_query_time": str(self._long_query_time),
+            "long_query_time": self._format_seconds(self._long_query_time),
             "log_slow_extra": "ON" if self._log_slow_extra else "OFF",
             "log_slow_admin_statements": "1" if self._log_slow_admin_statements else "0",
         }
@@ -149,9 +218,28 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
         return self._instance
 
     @property
+    def max_log_size_ceiling(self) -> int:
+        """
+        The most one capture may write, whatever the caller asks for.
+
+        A share of current allocated storage, so that a full-size capture
+        beginning at the reserve still cannot cross it.
+
+        :return: Bytes.
+        :rtype: int
+        """
+        return int(self._instance.allocated_storage_bytes * MAX_LOG_SIZE_RATIO)
+
+    @property
     def started_at(self) -> Optional[datetime]:
         """
-        :return: When the capture started (UTC), or ``None`` before :meth:`start`.
+        When queries actually began being logged, which is what bounds the
+        window and what ``pt-query-digest --since`` should be given.
+
+        Later than the moment :meth:`start` was called, by however long RDS took
+        to report the parameter group in-sync — typically a minute.
+
+        :return: UTC timestamp, or ``None`` before the parameters have landed.
         :rtype: Optional[datetime]
         """
         return self._started_at
@@ -165,12 +253,14 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
         :rtype: dict
         :raises SlowLogCaptureError: If called before :meth:`start`.
         """
-        if self._snapshot is None or self._started_at is None:
+        if self._snapshot is None or self._initiated_at is None:
             raise SlowLogCaptureError("Capture has not started, there is no state to record")
         return {
             "instance_id": self._instance.db_instance_id,
             "parameter_group": self._instance.parameter_group.name,
-            "started_at": self._started_at.isoformat(),
+            # When the change was requested, not when it landed — this file has
+            # to be written before the apply, so it cannot know the latter.
+            "started_at": self._initiated_at.isoformat(),
             "parameters": self._snapshot,
         }
 
@@ -208,13 +298,21 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
             LOG.warning("No slow log data was written during the capture window")
         return paths
 
-    def preflight(self, max_log_size: int = 0, min_free_storage: int = 0) -> None:
+    def preflight(self, max_log_size: int = None, min_free_storage: int = None) -> None:
         """
         Check that the capture is safe to run before anything is modified.
 
-        :param max_log_size: Log bytes the capture is allowed to write.
+        Both storage limits default to a share of *current* allocated storage,
+        so they mean the same thing on a 10 GiB instance and a 2 TiB one.  An
+        absolute default cannot: 20 GiB is nothing on the large volume and more
+        than the whole of the small one.
+
+        :param max_log_size: Log bytes the capture may write.  ``None`` for
+            :data:`MAX_LOG_SIZE_RATIO` of allocated storage.  A larger explicit
+            value is refused rather than clamped.
         :type max_log_size: int
-        :param min_free_storage: Free bytes that must remain available.
+        :param min_free_storage: Free bytes that must remain.  ``None`` for
+            :data:`FREE_STORAGE_RESERVE_RATIO` of allocated storage.
         :type min_free_storage: int
         :raises SlowLogCaptureError: If the instance, its parameter group, or
             its free storage make the capture unsafe.
@@ -244,20 +342,41 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
 
         group.validate_modifiable(list(self.desired_parameters))
 
+        allocated = self._instance.allocated_storage_bytes
+        max_log_size = self.default_max_log_size if max_log_size is None else max_log_size
+        min_free_storage = self.default_min_free_storage if min_free_storage is None else min_free_storage
+
+        if max_log_size > self.max_log_size_ceiling:
+            raise SlowLogCaptureError(
+                f"A {self._as_gib(max_log_size)} log is more than "
+                f"{MAX_LOG_SIZE_RATIO:.0%} of {self._as_gib(allocated)} allocated storage on "
+                f"{self._instance.db_instance_id}. Cap it at {self._as_gib(self.max_log_size_ceiling)} "
+                f"so a full capture cannot push free space under the autoscale threshold."
+            )
+
         free = self._instance.free_storage_bytes
         if free is None:
             raise SlowLogCaptureError(
                 "CloudWatch has no recent FreeStorageSpace datapoint for "
                 f"{self._instance.db_instance_id}; refusing to fill a volume whose free space cannot be verified"
             )
-        required = max_log_size + min_free_storage
-        if free < required:
+        if free - max_log_size < min_free_storage:
             raise SlowLogCaptureError(
-                f"{self._instance.db_instance_id} has {self._as_gib(free)} free, but the capture needs "
-                f"{self._as_gib(max_log_size)} of headroom on top of a {self._as_gib(min_free_storage)} reserve"
+                f"{self._instance.db_instance_id} has {self._as_gib(free)} free of "
+                f"{self._as_gib(allocated)} allocated. A {self._as_gib(max_log_size)} capture would leave "
+                f"{self._as_gib(free - max_log_size)}, under the {self._as_gib(min_free_storage)} reserve "
+                f"({FREE_STORAGE_RESERVE_RATIO:.0%} of allocated) that keeps RDS from autoextending the volume. "
+                f"Free up space, or lower --max-log-size below {self._as_gib(free - min_free_storage)}."
             )
+
         self._warn_about_cloudwatch_export()
-        LOG.info("Preflight passed: %s free on %s", self._as_gib(free), self._instance.db_instance_id)
+        LOG.info(
+            "Preflight passed: %s free of %s allocated, capture capped at %s, reserve %s",
+            self._as_gib(free),
+            self._as_gib(allocated),
+            self._as_gib(max_log_size),
+            self._as_gib(min_free_storage),
+        )
 
     def start(self) -> None:
         """
@@ -275,7 +394,9 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
         """
         group = self._instance.parameter_group
         self._snapshot = group.snapshot(CAPTURE_PARAMETERS)
-        self._started_at = datetime.now(timezone.utc)
+        self._initiated_at = datetime.now(timezone.utc)
+        # Taken before the parameters land, so files RDS creates on the way to
+        # in-sync count as captured rather than as pre-existing.
         self._baseline = {entry["name"]: entry["size"] for entry in self._instance.slow_log_files}
 
         self._write_state_file()
@@ -289,6 +410,16 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
             LOG.error("Could not start the capture on %s, rolling back", self._instance.db_instance_id)
             self.stop()
             raise
+
+        # The clock starts here, not above: RDS takes a minute or so to report
+        # the group in-sync, and nothing is being logged until it does. Stamping
+        # this before the apply spends the whole window on that latency.
+        self._started_at = datetime.now(timezone.utc)
+        LOG.info(
+            "Capturing from %s, %ds after the change was requested",
+            self._started_at.isoformat(),
+            (self._started_at - self._initiated_at).total_seconds(),
+        )
         self._warn_about_open_connections()
 
     def stop(self) -> None:
@@ -413,6 +544,24 @@ class SlowLogCapture:  # pylint: disable=too-many-instance-attributes
         :rtype: str
         """
         return f"{size / 1024 ** 3:.2f} GiB"
+
+    @staticmethod
+    def _format_seconds(value: float) -> str:
+        """
+        Render a seconds value the same way whatever numeric type it arrives as.
+
+        Click hands ``capture`` a float, so ``0`` becomes ``0.0`` while the
+        constructor default stays ``0`` — enough to make ``capture`` and
+        ``status`` disagree about the same setting.  Fixed decimal notation is
+        used rather than ``str()`` because ``str(0.000001)`` is ``1e-06``, and
+        six places is exactly MySQL's microsecond resolution.
+
+        :param value: Seconds.
+        :type value: float
+        :return: The value without a scientific-notation or trailing-zero tail.
+        :rtype: str
+        """
+        return f"{float(value):.6f}".rstrip("0").rstrip(".")
 
     def _install_sigterm_handler(self) -> None:
         """

--- a/infrahouse_toolkit/aws/tests/rds/test_instance.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_instance.py
@@ -1,0 +1,203 @@
+"""Tests for :class:`infrahouse_toolkit.aws.rds.RDSMySQLInstance`."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from botocore.credentials import Credentials
+from botocore.exceptions import ClientError
+
+from infrahouse_toolkit.aws.rds import RDSError, RDSInstanceNotFound, RDSMySQLInstance
+
+DESCRIPTION = {
+    "DBInstanceIdentifier": "test-instance",
+    "DBInstanceStatus": "available",
+    "Engine": "mysql",
+    "EngineVersion": "8.0.45",
+    "AllocatedStorage": 200,
+    "EnabledCloudwatchLogsExports": ["error", "general", "slowquery"],
+    "PerformanceInsightsEnabled": True,
+    "DBParameterGroups": [{"DBParameterGroupName": "test-pg", "ParameterApplyStatus": "in-sync"}],
+}
+
+
+@pytest.fixture()
+def session() -> MagicMock:
+    """Return a mock boto3 session whose RDS client describes one instance."""
+    rds = MagicMock()
+    rds.meta.region_name = "us-west-1"
+    rds.describe_db_instances.return_value = {"DBInstances": [DESCRIPTION]}
+    mock = MagicMock()
+    mock.region_name = "us-west-1"
+    mock.client.return_value = rds
+    mock.get_credentials.return_value = Credentials("AKIAEXAMPLE", "secret", "token")
+    return mock
+
+
+@pytest.fixture()
+def instance(session: MagicMock) -> RDSMySQLInstance:
+    """Return an RDSInstance backed by the mock session."""
+    return RDSMySQLInstance("test-instance", session=session)
+
+
+def test_basic_properties(instance: RDSMySQLInstance) -> None:
+    """Scalar properties come straight from describe_db_instances."""
+    assert instance.engine == "mysql"
+    assert instance.engine_version == "8.0.45"
+    assert instance.status == "available"
+    assert instance.allocated_storage_bytes == 200 * 1024**3
+    assert instance.cloudwatch_log_exports == ["error", "general", "slowquery"]
+    assert instance.performance_insights_enabled is True
+    assert instance.parameter_apply_status == "in-sync"
+    assert instance.parameter_group.name == "test-pg"
+
+
+def test_missing_instance(session: MagicMock) -> None:
+    """A nonexistent instance raises a typed error, not a raw ClientError."""
+    session.client.return_value.describe_db_instances.side_effect = ClientError(
+        {"Error": {"Code": "DBInstanceNotFound", "Message": "not found"}}, "DescribeDBInstances"
+    )
+    with pytest.raises(RDSInstanceNotFound):
+        _ = RDSMySQLInstance("nope", session=session).engine
+
+
+def test_other_client_errors_propagate(session: MagicMock) -> None:
+    """Errors that are not "missing instance" are not swallowed."""
+    session.client.return_value.describe_db_instances.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "DescribeDBInstances"
+    )
+    with pytest.raises(ClientError):
+        _ = RDSMySQLInstance("test-instance", session=session).engine
+
+
+def test_slow_log_files_sorted_oldest_first(instance: RDSMySQLInstance, session: MagicMock) -> None:
+    """Log files come back ordered by write time."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {
+            "DescribeDBLogFiles": [
+                {"LogFileName": "slowquery/mysql-slowquery.log", "Size": 300, "LastWritten": 3},
+                {"LogFileName": "slowquery/mysql-slowquery.log.2026-08-24.9", "Size": 100, "LastWritten": 1},
+            ]
+        }
+    ]
+    session.client.return_value.get_paginator.return_value = paginator
+
+    assert [entry["name"] for entry in instance.slow_log_files] == [
+        "slowquery/mysql-slowquery.log.2026-08-24.9",
+        "slowquery/mysql-slowquery.log",
+    ]
+    assert instance.slow_log_size == 400
+
+
+def test_slow_log_files_when_log_output_is_table(instance: RDSMySQLInstance, session: MagicMock) -> None:
+    """With log_output=TABLE there are no files at all — the common RDS default."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"DescribeDBLogFiles": []}]
+    session.client.return_value.get_paginator.return_value = paginator
+    assert instance.slow_log_files == []
+    assert instance.slow_log_size == 0
+
+
+def test_free_storage_bytes_uses_latest_datapoint(instance: RDSMySQLInstance, session: MagicMock) -> None:
+    """The most recent CloudWatch reading wins."""
+    cloudwatch = MagicMock()
+    cloudwatch.get_metric_statistics.return_value = {
+        "Datapoints": [
+            {"Timestamp": datetime(2026, 8, 24, 10, tzinfo=timezone.utc), "Minimum": 100.0},
+            {"Timestamp": datetime(2026, 8, 24, 11, tzinfo=timezone.utc), "Minimum": 90.0},
+        ]
+    }
+    session.client.side_effect = lambda name, **kwargs: cloudwatch if name == "cloudwatch" else MagicMock()
+    assert RDSMySQLInstance("test-instance", session=session).free_storage_bytes == 90
+
+
+def test_free_storage_bytes_without_datapoints(session: MagicMock) -> None:
+    """CloudWatch lag yields None rather than a made-up number."""
+    cloudwatch = MagicMock()
+    cloudwatch.get_metric_statistics.return_value = {"Datapoints": []}
+    session.client.side_effect = lambda name, **kwargs: cloudwatch if name == "cloudwatch" else MagicMock()
+    assert RDSMySQLInstance("test-instance", session=session).free_storage_bytes is None
+
+
+def test_wait_parameters_in_sync_returns_when_synced(instance: RDSMySQLInstance) -> None:
+    """Nothing to wait for once the group reports in-sync."""
+    with patch("infrahouse_toolkit.aws.rds.instance.time.sleep"):
+        instance.wait_parameters_in_sync(settle=0)
+
+
+def test_wait_parameters_in_sync_raises_on_failure(instance: RDSMySQLInstance, session: MagicMock) -> None:
+    """A failed apply is an error, not something to keep polling."""
+    session.client.return_value.describe_db_instances.return_value = {
+        "DBInstances": [
+            dict(
+                DESCRIPTION,
+                DBParameterGroups=[{"DBParameterGroupName": "test-pg", "ParameterApplyStatus": "failed-to-apply"}],
+            )
+        ]
+    }
+    with patch("infrahouse_toolkit.aws.rds.instance.time.sleep"):
+        with pytest.raises(RDSError) as exc_info:
+            instance.wait_parameters_in_sync(settle=0)
+    assert "failed to apply" in str(exc_info.value)
+
+
+def test_wait_parameters_in_sync_times_out(instance: RDSMySQLInstance, session: MagicMock) -> None:
+    """A group stuck in applying eventually gives up."""
+    session.client.return_value.describe_db_instances.return_value = {
+        "DBInstances": [
+            dict(
+                DESCRIPTION,
+                DBParameterGroups=[{"DBParameterGroupName": "test-pg", "ParameterApplyStatus": "applying"}],
+            )
+        ]
+    }
+    with patch("infrahouse_toolkit.aws.rds.instance.time.sleep"):
+        with pytest.raises(RDSError) as exc_info:
+            instance.wait_parameters_in_sync(timeout=0, settle=0)
+    assert "did not reach in-sync" in str(exc_info.value)
+
+
+def test_download_falls_back_to_portion_api(instance: RDSMySQLInstance, session: MagicMock, tmp_path) -> None:
+    """When the streaming endpoint fails, the paginated API finishes the job."""
+    rds = session.client.return_value
+    rds.download_db_log_file_portion.side_effect = [
+        {"LogFileData": "first\n", "Marker": "1", "AdditionalDataPending": True},
+        {"LogFileData": "second\n", "Marker": "2", "AdditionalDataPending": False},
+    ]
+    with patch(
+        "infrahouse_toolkit.aws.rds.instance.requests.get",
+        side_effect=requests.RequestException("nope"),
+    ):
+        path = instance.download_log_file("slowquery/mysql-slowquery.log", str(tmp_path))
+
+    assert open(path, encoding="utf8").read() == "first\nsecond\n"
+    assert rds.download_db_log_file_portion.call_count == 2
+
+
+def test_download_streams_complete_log_file(instance: RDSMySQLInstance, tmp_path) -> None:
+    """The signed REST endpoint is tried first and streams the whole file."""
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.iter_content.return_value = [b"slow log ", b"contents"]
+
+    with patch("infrahouse_toolkit.aws.rds.instance.requests.get", return_value=response) as mock_get:
+        path = instance.download_log_file("slowquery/mysql-slowquery.log", str(tmp_path))
+
+    url = mock_get.call_args.args[0]
+    assert url == (
+        "https://rds.us-west-1.amazonaws.com/v13/downloadCompleteLogFile/test-instance/" "slowquery/mysql-slowquery.log"
+    )
+    assert "Authorization" in mock_get.call_args.kwargs["headers"]
+    assert open(path, "rb").read() == b"slow log contents"
+
+
+def test_download_names_file_without_slashes(instance: RDSMySQLInstance, tmp_path) -> None:
+    """The RDS log name contains a directory part that must not become one locally."""
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.iter_content.return_value = [b""]
+    with patch("infrahouse_toolkit.aws.rds.instance.requests.get", return_value=response):
+        path = instance.download_log_file("slowquery/mysql-slowquery.log", str(tmp_path))
+    assert path.endswith("slowquery-mysql-slowquery.log")

--- a/infrahouse_toolkit/aws/tests/rds/test_instance_list.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_instance_list.py
@@ -1,0 +1,82 @@
+"""Tests for :class:`infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list.InstanceList`."""
+
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list import InstanceList
+
+LIST_INSTANCES = "infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list.RDSMySQLInstance.list_instances"
+
+
+def make_instance(identifier: str, tags: dict = None) -> MagicMock:
+    """Return a mock RDSMySQLInstance the listing can render."""
+    instance = MagicMock()
+    instance.db_instance_id = identifier
+    instance.engine = "mysql"
+    instance.engine_version = "8.0.45"
+    instance.status = "available"
+    instance.tags = tags or {}
+    instance.description = {"DBInstanceClass": "db.t3.large"}
+    return instance
+
+
+@pytest.fixture()
+def listing() -> InstanceList:
+    """Return a listing over two instances."""
+    instances = [
+        make_instance("mysql-one", {"Name": "first instance"}),
+        make_instance("mysql-two", {"service": "second-service"}),
+    ]
+    result = InstanceList(MagicMock())
+    with patch(LIST_INSTANCES, return_value=instances):
+        _ = result.instances
+    return result
+
+
+def test_table_shows_a_row_per_instance(listing: InstanceList) -> None:
+    """Both instances are listed with their class and state."""
+    table = listing.table
+    assert "mysql-one" in table
+    assert "mysql-two" in table
+    assert "db.t3.large" in table
+    assert "available" in table
+
+
+def test_table_prefers_name_tag_then_service(listing: InstanceList) -> None:
+    """Name is the label when present; service is the fallback."""
+    table = listing.table
+    assert "first instance" in table
+    assert "second-service" in table
+
+
+def test_table_has_no_selection_numbers(listing: InstanceList) -> None:
+    """Instances are chosen by identifier, so a number column would mislead."""
+    assert listing.table.splitlines()[1].strip().startswith("| Name")
+
+
+def test_require_resolves_a_given_identifier(listing: InstanceList) -> None:
+    """A supplied identifier is used directly, without listing anything."""
+    with patch("infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list.RDSMySQLInstance") as mock_instance:
+        assert listing.require("some-db") is mock_instance.return_value
+    mock_instance.assert_called_once()
+
+
+def test_require_without_identifier_lists_choices(listing: InstanceList) -> None:
+    """A missing argument fails with the valid identifiers, not a prompt."""
+    with pytest.raises(click.UsageError) as exc_info:
+        listing.require(None)
+    message = str(exc_info.value)
+    assert "Missing argument 'INSTANCE_ID'" in message
+    assert "mysql-one" in message
+    assert "mysql-two" in message
+
+
+def test_require_without_identifier_and_no_instances() -> None:
+    """An empty region says so rather than printing an empty table."""
+    listing = InstanceList(MagicMock())
+    with patch(LIST_INSTANCES, return_value=[]):
+        with pytest.raises(click.UsageError) as exc_info:
+            listing.require(None)
+    assert "no RDS for MySQL instances were found" in str(exc_info.value)

--- a/infrahouse_toolkit/aws/tests/rds/test_instance_list.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_instance_list.py
@@ -5,9 +5,13 @@ from unittest.mock import MagicMock, patch
 import click
 import pytest
 
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit import instance_list
 from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list import InstanceList
 
-LIST_INSTANCES = "infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list.RDSMySQLInstance.list_instances"
+# Patch through the imported module rather than a dotted string. ih_mysql/__init__.py binds the
+# name cmd_query_audit to the click group, which shadows the submodule of the same name on the
+# package, so a string target resolves to a Group and fails on Python 3.10 -- 3.11 switched
+# mock to pkgutil.resolve_name and no longer walks attributes.
 
 
 def make_instance(identifier: str, tags: dict = None) -> MagicMock:
@@ -30,7 +34,7 @@ def listing() -> InstanceList:
         make_instance("mysql-two", {"service": "second-service"}),
     ]
     result = InstanceList(MagicMock())
-    with patch(LIST_INSTANCES, return_value=instances):
+    with patch.object(instance_list.RDSMySQLInstance, "list_instances", return_value=instances):
         _ = result.instances
     return result
 
@@ -58,7 +62,7 @@ def test_table_has_no_selection_numbers(listing: InstanceList) -> None:
 
 def test_require_resolves_a_given_identifier(listing: InstanceList) -> None:
     """A supplied identifier is used directly, without listing anything."""
-    with patch("infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list.RDSMySQLInstance") as mock_instance:
+    with patch.object(instance_list, "RDSMySQLInstance") as mock_instance:
         assert listing.require("some-db") is mock_instance.return_value
     mock_instance.assert_called_once()
 
@@ -76,7 +80,7 @@ def test_require_without_identifier_lists_choices(listing: InstanceList) -> None
 def test_require_without_identifier_and_no_instances() -> None:
     """An empty region says so rather than printing an empty table."""
     listing = InstanceList(MagicMock())
-    with patch(LIST_INSTANCES, return_value=[]):
+    with patch.object(instance_list.RDSMySQLInstance, "list_instances", return_value=[]):
         with pytest.raises(click.UsageError) as exc_info:
             listing.require(None)
     assert "no RDS for MySQL instances were found" in str(exc_info.value)

--- a/infrahouse_toolkit/aws/tests/rds/test_list_instances.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_list_instances.py
@@ -1,0 +1,85 @@
+"""Tests for :meth:`infrahouse_toolkit.aws.rds.RDSMySQLInstance.list_instances`."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrahouse_toolkit.aws.rds import RDSMySQLInstance
+
+PAGE = {
+    "DBInstances": [
+        {
+            "DBInstanceIdentifier": "mysql-two",
+            "Engine": "mysql",
+            "EngineVersion": "8.0.45",
+            "DBInstanceClass": "db.t3.large",
+            "DBInstanceStatus": "available",
+            "TagList": [{"Key": "service", "Value": "second-service"}],
+        },
+        {
+            "DBInstanceIdentifier": "postgres-one",
+            "Engine": "postgres",
+            "EngineVersion": "16.3",
+            "DBInstanceClass": "db.t3.micro",
+            "DBInstanceStatus": "available",
+            "TagList": [],
+        },
+        {
+            "DBInstanceIdentifier": "mysql-one",
+            "Engine": "mysql",
+            "EngineVersion": "8.4.0",
+            "DBInstanceClass": "db.t4g.medium",
+            "DBInstanceStatus": "available",
+            "TagList": [{"Key": "Name", "Value": "first instance"}],
+        },
+    ]
+}
+
+
+@pytest.fixture()
+def session() -> MagicMock:
+    """Return a mock session whose RDS paginator yields one page of instances."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = [PAGE]
+    rds = MagicMock()
+    rds.get_paginator.return_value = paginator
+    mock = MagicMock()
+    mock.client.return_value = rds
+    return mock
+
+
+def test_lists_only_mysql_sorted(session: MagicMock) -> None:
+    """Postgres is filtered out and the rest come back ordered by identifier."""
+    instances = RDSMySQLInstance.list_instances(session=session)
+    assert [i.db_instance_id for i in instances] == ["mysql-one", "mysql-two"]
+
+
+def test_every_engine_when_prefix_is_empty(session: MagicMock) -> None:
+    """An empty prefix disables the engine filter."""
+    instances = RDSMySQLInstance.list_instances(engine_prefix="", session=session)
+    assert len(instances) == 3
+
+
+def test_returned_instances_need_no_extra_api_call(session: MagicMock) -> None:
+    """The description is seeded from the bulk call, so reads are free."""
+    instances = RDSMySQLInstance.list_instances(session=session)
+    rds = session.client.return_value
+    rds.describe_db_instances.reset_mock()
+
+    assert instances[1].engine == "mysql"
+    assert instances[1].engine_version == "8.0.45"
+    assert instances[1].status == "available"
+    assert instances[1].tags == {"service": "second-service"}
+    rds.describe_db_instances.assert_not_called()
+
+
+def test_tags_without_tag_list(session: MagicMock) -> None:
+    """An instance with no tags yields an empty dict, not an error."""
+    instances = RDSMySQLInstance.list_instances(engine_prefix="postgres", session=session)
+    assert instances[0].tags == {}
+
+
+def test_empty_account(session: MagicMock) -> None:
+    """No instances is an empty list, not an exception."""
+    session.client.return_value.get_paginator.return_value.paginate.return_value = [{"DBInstances": []}]
+    assert RDSMySQLInstance.list_instances(session=session) == []

--- a/infrahouse_toolkit/aws/tests/rds/test_parameter_group.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_parameter_group.py
@@ -1,0 +1,217 @@
+"""Tests for :class:`infrahouse_toolkit.aws.rds.RDSParameterGroup`."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from infrahouse_toolkit.aws.rds import RDSParameterError, RDSParameterGroup
+
+PARAMETERS = {
+    "log_output": {
+        "ParameterName": "log_output",
+        "ParameterValue": "TABLE",
+        "Source": "system",
+        "ApplyType": "dynamic",
+        "IsModifiable": True,
+    },
+    "long_query_time": {
+        "ParameterName": "long_query_time",
+        "Source": "engine-default",
+        "ApplyType": "dynamic",
+        "IsModifiable": True,
+    },
+    "slow_query_log": {
+        "ParameterName": "slow_query_log",
+        "ParameterValue": "1",
+        "Source": "user",
+        "ApplyType": "dynamic",
+        "IsModifiable": True,
+    },
+    "slow_query_log_file": {
+        "ParameterName": "slow_query_log_file",
+        "ParameterValue": "/rdsdbdata/log/slowquery/mysql-slowquery.log",
+        "Source": "system",
+        "ApplyType": "dynamic",
+        "IsModifiable": False,
+    },
+    "performance_schema": {
+        "ParameterName": "performance_schema",
+        "ParameterValue": "0",
+        "Source": "system",
+        "ApplyType": "static",
+        "IsModifiable": True,
+    },
+}
+
+
+@pytest.fixture()
+def rds_client() -> MagicMock:
+    """Return a mock RDS client serving one mysql8.0 parameter group."""
+    client = MagicMock()
+    client.describe_db_parameter_groups.return_value = {
+        "DBParameterGroups": [{"DBParameterGroupName": "test-pg", "DBParameterGroupFamily": "mysql8.0"}]
+    }
+
+    def paginator_for(name):
+        paginator = MagicMock()
+        if name == "describe_db_parameters":
+            paginator.paginate.return_value = [{"Parameters": list(PARAMETERS.values())}]
+        else:
+            paginator.paginate.return_value = [
+                {
+                    "DBInstances": [
+                        {
+                            "DBInstanceIdentifier": "test-instance",
+                            "DBParameterGroups": [{"DBParameterGroupName": "test-pg"}],
+                        },
+                        {
+                            "DBInstanceIdentifier": "other-instance",
+                            "DBParameterGroups": [{"DBParameterGroupName": "other-pg"}],
+                        },
+                    ]
+                }
+            ]
+        return paginator
+
+    client.get_paginator.side_effect = paginator_for
+    return client
+
+
+@pytest.fixture()
+def group(rds_client: MagicMock) -> RDSParameterGroup:
+    """Return an RDSParameterGroup backed by the mock client."""
+    session = MagicMock()
+    session.client.return_value = rds_client
+    return RDSParameterGroup("test-pg", session=session)
+
+
+def test_family(group: RDSParameterGroup) -> None:
+    """family comes from describe_db_parameter_groups."""
+    assert group.family == "mysql8.0"
+
+
+def test_attached_instance_ids(group: RDSParameterGroup) -> None:
+    """Only instances actually using the group are reported."""
+    assert group.attached_instance_ids == ["test-instance"]
+
+
+def test_is_default() -> None:
+    """RDS-provided groups are recognised by their name prefix."""
+    assert RDSParameterGroup("default.mysql8.0", session=MagicMock()).is_default is True
+    assert RDSParameterGroup("test-pg", session=MagicMock()).is_default is False
+
+
+def test_value_of_unset_parameter(group: RDSParameterGroup) -> None:
+    """A parameter inheriting the engine default has no value."""
+    assert group.value_of("long_query_time") is None
+    assert group.value_of("log_output") == "TABLE"
+
+
+def test_apply_sets_parameters_immediately(group: RDSParameterGroup, rds_client: MagicMock) -> None:
+    """apply() writes every value with ApplyMethod=immediate."""
+    group.apply({"log_output": "FILE", "long_query_time": "0"})
+    kwargs = rds_client.modify_db_parameter_group.call_args.kwargs
+    assert kwargs["DBParameterGroupName"] == "test-pg"
+    assert kwargs["Parameters"] == [
+        {"ParameterName": "log_output", "ParameterValue": "FILE", "ApplyMethod": "immediate"},
+        {"ParameterName": "long_query_time", "ParameterValue": "0", "ApplyMethod": "immediate"},
+    ]
+
+
+def test_apply_rejects_default_group() -> None:
+    """A default parameter group cannot be modified at all."""
+    group = RDSParameterGroup("default.mysql8.0", session=MagicMock())
+    with pytest.raises(RDSParameterError) as exc_info:
+        group.apply({"log_output": "FILE"})
+    assert "default parameter group" in str(exc_info.value)
+
+
+def test_validate_modifiable_rejects_read_only(group: RDSParameterGroup) -> None:
+    """slow_query_log_file is fixed on RDS and must be refused."""
+    with pytest.raises(RDSParameterError) as exc_info:
+        group.validate_modifiable(["slow_query_log_file"])
+    assert "not modifiable" in str(exc_info.value)
+
+
+def test_validate_modifiable_rejects_static(group: RDSParameterGroup) -> None:
+    """A static parameter would need a reboot, so it is refused up front."""
+    with pytest.raises(RDSParameterError) as exc_info:
+        group.validate_modifiable(["performance_schema"])
+    assert "not dynamic" in str(exc_info.value)
+
+
+def test_validate_modifiable_rejects_unknown(group: RDSParameterGroup) -> None:
+    """A parameter absent from the family (e.g. a Percona-only one) is refused."""
+    with pytest.raises(RDSParameterError) as exc_info:
+        group.validate_modifiable(["log_slow_verbosity"])
+    assert "does not exist in family mysql8.0" in str(exc_info.value)
+
+
+def test_snapshot_records_value_and_source(group: RDSParameterGroup) -> None:
+    """snapshot() keeps the origin, not just the value."""
+    assert group.snapshot(["slow_query_log", "long_query_time"]) == [
+        {"name": "slow_query_log", "value": "1", "source": "user"},
+        {"name": "long_query_time", "value": None, "source": "engine-default"},
+    ]
+
+
+def test_snapshot_rejects_unknown_parameter(group: RDSParameterGroup) -> None:
+    """Recording a parameter that does not exist is an error, not a None entry."""
+    with pytest.raises(RDSParameterError):
+        group.snapshot(["use_global_long_query_time"])
+
+
+def test_restore_sets_user_values_and_resets_defaults(group: RDSParameterGroup, rds_client: MagicMock) -> None:
+    """User-set parameters are written back; inherited ones are reset, not pinned."""
+    group.restore(
+        [
+            {"name": "slow_query_log", "value": "1", "source": "user"},
+            {"name": "long_query_time", "value": None, "source": "engine-default"},
+            {"name": "log_output", "value": "TABLE", "source": "system"},
+        ]
+    )
+    assert rds_client.modify_db_parameter_group.call_args.kwargs["Parameters"] == [
+        {"ParameterName": "slow_query_log", "ParameterValue": "1", "ApplyMethod": "immediate"}
+    ]
+    assert rds_client.reset_db_parameter_group.call_args.kwargs["Parameters"] == [
+        {"ParameterName": "long_query_time", "ApplyMethod": "immediate"},
+        {"ParameterName": "log_output", "ApplyMethod": "immediate"},
+    ]
+
+
+def test_restore_without_user_values_only_resets(group: RDSParameterGroup, rds_client: MagicMock) -> None:
+    """Nothing is written when every parameter was inherited."""
+    group.restore([{"name": "long_query_time", "value": None, "source": "engine-default"}])
+    rds_client.modify_db_parameter_group.assert_not_called()
+    rds_client.reset_db_parameter_group.assert_called_once()
+
+
+def test_exists(group: RDSParameterGroup) -> None:
+    """The AWSResource contract: the group is there."""
+    assert group.exists is True
+
+
+def test_does_not_exist(group: RDSParameterGroup, rds_client: MagicMock) -> None:
+    """A missing group is False, not an exception."""
+    rds_client.describe_db_parameter_groups.side_effect = ClientError(
+        {"Error": {"Code": "DBParameterGroupNotFound", "Message": "nope"}}, "DescribeDBParameterGroups"
+    )
+    assert group.exists is False
+
+
+def test_exists_propagates_other_errors(group: RDSParameterGroup, rds_client: MagicMock) -> None:
+    """A permissions problem must not read as "does not exist"."""
+    rds_client.describe_db_parameter_groups.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "DescribeDBParameterGroups"
+    )
+    with pytest.raises(ClientError):
+        _ = group.exists
+
+
+def test_delete_is_idempotent(group: RDSParameterGroup, rds_client: MagicMock) -> None:
+    """Deleting a group that is already gone is a no-op."""
+    rds_client.delete_db_parameter_group.side_effect = ClientError(
+        {"Error": {"Code": "DBParameterGroupNotFound", "Message": "nope"}}, "DeleteDBParameterGroup"
+    )
+    group.delete()

--- a/infrahouse_toolkit/aws/tests/rds/test_query_digest.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_query_digest.py
@@ -1,0 +1,71 @@
+"""Tests for :class:`infrahouse_toolkit.aws.rds.QueryDigest`."""
+
+from datetime import datetime, timezone
+from subprocess import CalledProcessError
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infrahouse_toolkit.aws.rds import QueryDigest, QueryDigestError
+
+
+def test_command_defaults() -> None:
+    """The default report ranks queries by total time."""
+    assert QueryDigest(["slow.log"]).command() == [
+        "pt-query-digest",
+        "--group-by",
+        "fingerprint",
+        "--order-by",
+        "Query_time:sum",
+        "--limit",
+        "20",
+        "slow.log",
+    ]
+
+
+def test_command_with_since_and_filter() -> None:
+    """--since drops events RDS wrote to the file before the capture began."""
+    digest = QueryDigest(
+        ["a.log", "b.log"],
+        since=datetime(2026, 8, 24, 14, 30, 0, tzinfo=timezone.utc),
+    )
+    command = digest.command(group_by="tables", query_filter="$event->{arg} =~ m/fetch_results/")
+    assert "--since" in command
+    assert command[command.index("--since") + 1] == "2026-08-24 14:30:00"
+    assert command[command.index("--group-by") + 1] == "tables"
+    assert command[command.index("--filter") + 1] == "$event->{arg} =~ m/fetch_results/"
+    assert command[-2:] == ["a.log", "b.log"]
+
+
+def test_command_without_log_files() -> None:
+    """A capture that produced nothing must not silently digest nothing."""
+    with pytest.raises(QueryDigestError) as exc_info:
+        QueryDigest([]).command()
+    assert "No slow log files" in str(exc_info.value)
+
+
+def test_report_writes_output(tmp_path) -> None:
+    """Whatever pt-query-digest prints lands in the report file."""
+    result = MagicMock()
+    result.stdout = "# Profile\n"
+    destination = tmp_path / "digest.txt"
+    with patch("infrahouse_toolkit.aws.rds.query_digest.run", return_value=result):
+        assert QueryDigest(["slow.log"]).report(str(destination)) == str(destination)
+    assert destination.read_text() == "# Profile\n"
+
+
+def test_report_without_percona_toolkit(tmp_path) -> None:
+    """A missing binary says how to install it."""
+    with patch("infrahouse_toolkit.aws.rds.query_digest.run", side_effect=FileNotFoundError):
+        with pytest.raises(QueryDigestError) as exc_info:
+            QueryDigest(["slow.log"]).report(str(tmp_path / "digest.txt"))
+    assert "percona-toolkit" in str(exc_info.value)
+
+
+def test_report_when_digest_fails(tmp_path) -> None:
+    """A non-zero exit carries the tool's own stderr."""
+    error = CalledProcessError(returncode=2, cmd="pt-query-digest", stderr="bad --filter")
+    with patch("infrahouse_toolkit.aws.rds.query_digest.run", side_effect=error):
+        with pytest.raises(QueryDigestError) as exc_info:
+            QueryDigest(["slow.log"]).report(str(tmp_path / "digest.txt"))
+    assert "bad --filter" in str(exc_info.value)

--- a/infrahouse_toolkit/aws/tests/rds/test_query_digest.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_query_digest.py
@@ -69,3 +69,48 @@ def test_report_when_digest_fails(tmp_path) -> None:
         with pytest.raises(QueryDigestError) as exc_info:
             QueryDigest(["slow.log"]).report(str(tmp_path / "digest.txt"))
     assert "bad --filter" in str(exc_info.value)
+
+
+# What RDS leaves in a freshly created slow log file before any query is logged.
+HEADER = (
+    "/rdsdbbin/mysql/bin/mysqld, Version: 8.0.45 (Source distribution). started with:\n"
+    "Tcp port: 3306  Unix socket: /tmp/mysql.sock\n"
+    "Time                 Id Command    Argument\n"
+)
+
+EVENT = (
+    "# Time: 2026-08-24T17:40:00.000000Z\n"
+    "# User@Host: app[app] @  [10.0.0.1]  Id:    42\n"
+    "# Query_time: 0.000512  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 1\n"
+    "SET timestamp=1756056000;\n"
+    "SELECT 1;\n"
+)
+
+
+def test_event_count_ignores_the_header(tmp_path) -> None:
+    """A capture that logged nothing still leaves a non-empty file — that is not a capture."""
+    log = tmp_path / "slow.log"
+    log.write_text(HEADER)
+    assert log.stat().st_size > 0
+    assert QueryDigest([str(log)]).event_count == 0
+
+
+def test_event_count_counts_queries(tmp_path) -> None:
+    """Each logged query is one event."""
+    log = tmp_path / "slow.log"
+    log.write_text(HEADER + EVENT + EVENT)
+    assert QueryDigest([str(log)]).event_count == 2
+
+
+def test_event_count_across_rotated_files(tmp_path) -> None:
+    """RDS rotates hourly, so a long capture spans several files."""
+    first = tmp_path / "slow.log.1"
+    first.write_text(HEADER + EVENT)
+    second = tmp_path / "slow.log.2"
+    second.write_text(HEADER + EVENT + EVENT)
+    assert QueryDigest([str(first), str(second)]).event_count == 3
+
+
+def test_event_count_without_log_files() -> None:
+    """No files means no events, not an error."""
+    assert QueryDigest([]).event_count == 0

--- a/infrahouse_toolkit/aws/tests/rds/test_slow_log_capture.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_slow_log_capture.py
@@ -1,6 +1,7 @@
 """Tests for :class:`infrahouse_toolkit.aws.rds.SlowLogCapture`."""
 
 import json
+from datetime import datetime, timezone
 from os import path as osp
 from unittest.mock import MagicMock, patch
 
@@ -43,6 +44,8 @@ def instance() -> MagicMock:
     mock.engine_version = "8.0.45"
     mock.status = "available"
     mock.free_storage_bytes = 180 * GIB
+    mock.allocated_storage_bytes = 200 * GIB
+    mock.max_allocated_storage_bytes = 500 * GIB
     mock.slow_log_files = []
     mock.cloudwatch_log_exports = []
     mock.parameter_group = group
@@ -125,11 +128,11 @@ def test_preflight_allows_shared_group_when_asked(instance: MagicMock, tmp_path)
 
 
 def test_preflight_rejects_insufficient_storage(instance: MagicMock, capture: SlowLogCapture) -> None:
-    """A capture must not be able to fill the data volume."""
+    """A capture must not be able to push free space under the reserve."""
     instance.free_storage_bytes = 21 * GIB
     with pytest.raises(SlowLogCaptureError) as exc_info:
         capture.preflight(max_log_size=5 * GIB, min_free_storage=20 * GIB)
-    assert "headroom" in str(exc_info.value)
+    assert "under the 20.00 GiB reserve" in str(exc_info.value)
 
 
 def test_preflight_rejects_unknown_storage(instance: MagicMock, capture: SlowLogCapture) -> None:
@@ -342,3 +345,139 @@ def test_start_rollback_keeps_state_file_when_it_also_fails(capture: SlowLogCapt
     with pytest.raises(RDSError):
         capture.start()
     assert osp.exists(capture.state_file)
+
+
+@pytest.mark.parametrize(
+    "given, expected",
+    [
+        (0, "0"),
+        (0.0, "0"),  # click hands capture a float; status uses the int default
+        (2, "2"),
+        (2.0, "2"),
+        (10.0, "10"),
+        (0.5, "0.5"),
+        (1.25, "1.25"),
+        (0.000001, "0.000001"),  # str() would render this as 1e-06
+    ],
+)
+def test_long_query_time_renders_consistently(instance: MagicMock, given, expected) -> None:
+    """The same threshold renders identically whether it arrives as int or float."""
+    capture = SlowLogCapture(instance, long_query_time=given)
+    assert capture.desired_parameters["long_query_time"] == expected
+
+
+def test_reserve_scales_with_the_volume(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """The reserve is a share of allocated storage, so it means the same on any volume."""
+    instance.allocated_storage_bytes = 200 * GIB
+    assert capture.default_min_free_storage == 20 * GIB
+
+    instance.allocated_storage_bytes = 10 * GIB
+    assert capture.default_min_free_storage == 1 * GIB
+
+
+def test_default_log_size_is_a_working_size_not_the_ceiling(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """5% of a big volume is a ceiling, not something anyone wants to download."""
+    instance.allocated_storage_bytes = 2048 * GIB
+    assert capture.max_log_size_ceiling == 102 * GIB + int(0.4 * GIB)
+    assert capture.default_max_log_size == 1 * GIB
+
+
+def test_default_log_size_yields_to_the_ceiling_on_small_volumes(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """On a 10 GiB volume 5% is under a gigabyte, and the ceiling wins."""
+    instance.allocated_storage_bytes = 10 * GIB
+    assert capture.max_log_size_ceiling == 0.5 * GIB
+    assert capture.default_max_log_size == 0.5 * GIB
+
+
+def test_defaults_fit_a_small_volume(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """The 20 GiB flat default was unsatisfiable on a 10 GiB instance; the ratio is not."""
+    instance.allocated_storage_bytes = 10 * GIB
+    instance.free_storage_bytes = 1.7 * GIB
+    capture.preflight()
+
+
+def test_defaults_scale_up_to_a_large_volume(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """On a 2 TiB volume a 20 GiB reserve would have been far too thin."""
+    instance.allocated_storage_bytes = 2048 * GIB
+    instance.free_storage_bytes = 400 * GIB
+    capture.preflight()
+    assert capture.default_min_free_storage == 204 * GIB + int(0.8 * GIB)
+
+
+def test_preflight_refuses_an_oversized_log_cap(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """An explicit --max-log-size above 5% of the volume is refused, not clamped."""
+    instance.allocated_storage_bytes = 10 * GIB
+    instance.free_storage_bytes = 9 * GIB
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight(max_log_size=2 * GIB)
+    assert "more than 5%" in str(exc_info.value)
+
+
+def test_preflight_allows_a_smaller_log_cap(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """Asking for less than the ceiling is always fine."""
+    instance.allocated_storage_bytes = 10 * GIB
+    instance.free_storage_bytes = 9 * GIB
+    capture.preflight(max_log_size=100 * 1024**2)
+
+
+def test_preflight_allows_up_to_the_ceiling_above_the_default(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """The 1 GiB default is a default; the 5% ceiling is what is enforced."""
+    instance.allocated_storage_bytes = 2048 * GIB
+    instance.free_storage_bytes = 900 * GIB
+    capture.preflight(max_log_size=50 * GIB)
+
+
+def test_preflight_ignores_autoscaling_headroom(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """Room the volume could grow into is not room the capture may spend."""
+    instance.allocated_storage_bytes = 10 * GIB
+    instance.max_allocated_storage_bytes = 150 * GIB
+    instance.free_storage_bytes = 0.9 * GIB  # under the 1 GiB reserve
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight()
+    assert "autoextending" in str(exc_info.value)
+
+
+def test_reserve_is_the_autoextend_threshold(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """The reserve is RDS's own 10% trigger, not a round number."""
+    instance.allocated_storage_bytes = 137 * GIB
+    assert capture.default_min_free_storage == int(137 * GIB * 0.10)
+
+
+def test_clock_starts_after_the_parameters_land(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """RDS takes ~a minute to report in-sync; that must not come out of the window."""
+    stamps = []
+
+    def slow_apply(_values):
+        stamps.append("apply")
+
+    def slow_wait(*args, **kwargs):  # pylint: disable=unused-argument
+        stamps.append("wait")
+
+    instance.parameter_group.apply.side_effect = slow_apply
+    instance.wait_parameters_in_sync.side_effect = slow_wait
+
+    before = datetime.now(timezone.utc)
+    capture.start()
+
+    assert stamps == ["apply", "wait"]
+    # started_at is stamped after both, so the window is measured from the point
+    # queries are actually being logged.
+    assert capture.started_at >= before
+
+
+def test_state_file_timestamp_survives_a_failed_apply(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """The state file is written before the apply, so it records the request time."""
+    instance.wait_parameters_in_sync.side_effect = RDSError("timed out")
+    with pytest.raises(RDSError):
+        capture.start()
+    # start() rolled back and removed the state file, but it existed with a
+    # timestamp even though started_at was never reached.
+    assert capture.started_at is None
+
+
+def test_watch_measures_from_when_logging_began(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """The deadline runs from started_at, which is post-in-sync."""
+    capture.start()
+    assert capture.started_at is not None
+    reason = capture.watch(max_run_time=0, max_log_size=100 * GIB, min_free_storage=GIB)
+    assert "time limit" in reason

--- a/infrahouse_toolkit/aws/tests/rds/test_slow_log_capture.py
+++ b/infrahouse_toolkit/aws/tests/rds/test_slow_log_capture.py
@@ -1,0 +1,344 @@
+"""Tests for :class:`infrahouse_toolkit.aws.rds.SlowLogCapture`."""
+
+import json
+from os import path as osp
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infrahouse_toolkit.aws.rds import (
+    CAPTURE_PARAMETERS,
+    RDSError,
+    RDSMySQLInstance,
+    RDSParameterError,
+    RDSParameterGroup,
+    SlowLogCapture,
+    SlowLogCaptureError,
+)
+
+GIB = 1024**3
+
+
+@pytest.fixture()
+def instance() -> MagicMock:
+    """
+    Return a mock RDSMySQLInstance on a healthy, dedicated parameter group.
+
+    Specced against the real classes so that reading an attribute they do not
+    have raises instead of quietly returning another mock — an unspecced mock
+    happily answers to a stale name after a rename.
+    """
+    group = MagicMock(spec=RDSParameterGroup)
+    group.name = "test-pg"
+    group.is_default = False
+    group.attached_instance_ids = ["test-instance"]
+    group.value_of.return_value = "0"
+    group.snapshot.return_value = [
+        {"name": name, "value": None, "source": "engine-default"} for name in CAPTURE_PARAMETERS
+    ]
+
+    mock = MagicMock(spec=RDSMySQLInstance)
+    mock.db_instance_id = "test-instance"
+    mock.engine = "mysql"
+    mock.engine_version = "8.0.45"
+    mock.status = "available"
+    mock.free_storage_bytes = 180 * GIB
+    mock.slow_log_files = []
+    mock.cloudwatch_log_exports = []
+    mock.parameter_group = group
+    return mock
+
+
+@pytest.fixture()
+def capture(instance: MagicMock, tmp_path) -> SlowLogCapture:
+    """Return a SlowLogCapture writing its state file into a temp directory."""
+    return SlowLogCapture(instance, state_file=str(tmp_path / "state.json"))
+
+
+def test_desired_parameters_flip_log_output_to_file(capture: SlowLogCapture) -> None:
+    """log_output=FILE is mandatory: TABLE produces no file and mutes log_slow_extra."""
+    assert capture.desired_parameters == {
+        "log_output": "FILE",
+        "slow_query_log": "1",
+        "long_query_time": "0",
+        "log_slow_extra": "ON",
+        "log_slow_admin_statements": "1",
+    }
+
+
+def test_default_state_file_is_named_after_the_instance(instance: MagicMock) -> None:
+    """Without an explicit path the state file carries the DB instance identifier."""
+    assert SlowLogCapture(instance).state_file == "ih-query-audit-test-instance.state.json"
+
+
+def test_desired_parameters_honour_options(instance: MagicMock) -> None:
+    """Threshold and extra attributes are configurable."""
+    capture = SlowLogCapture(instance, long_query_time=0.5, log_slow_extra=False, log_slow_admin_statements=False)
+    assert capture.desired_parameters["long_query_time"] == "0.5"
+    assert capture.desired_parameters["log_slow_extra"] == "OFF"
+    assert capture.desired_parameters["log_slow_admin_statements"] == "0"
+
+
+def test_preflight_passes(capture: SlowLogCapture) -> None:
+    """A healthy instance with headroom passes."""
+    capture.preflight(max_log_size=GIB, min_free_storage=20 * GIB)
+
+
+def test_preflight_rejects_non_mysql(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """Postgres has a different slow-log mechanism entirely."""
+    instance.engine = "postgres"
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight()
+    assert "supports RDS for MySQL" in str(exc_info.value)
+
+
+def test_preflight_rejects_unavailable_instance(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """An instance mid-modification will not apply parameters predictably."""
+    instance.status = "modifying"
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight()
+    assert "expected available" in str(exc_info.value)
+
+
+def test_preflight_rejects_default_parameter_group(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """Default groups cannot be modified, and swapping groups needs a reboot."""
+    instance.parameter_group.is_default = True
+    instance.parameter_group.name = "default.mysql8.0"
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight()
+    assert "default parameter group" in str(exc_info.value)
+
+
+def test_preflight_rejects_shared_parameter_group(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """A shared group would turn the slow log up on every attached instance."""
+    instance.parameter_group.attached_instance_ids = ["test-instance", "test-instance-replica"]
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight()
+    assert "attached to 2 instances" in str(exc_info.value)
+
+
+def test_preflight_allows_shared_group_when_asked(instance: MagicMock, tmp_path) -> None:
+    """The shared-group guard is a guard, not a wall."""
+    instance.parameter_group.attached_instance_ids = ["test-instance", "test-instance-replica"]
+    capture = SlowLogCapture(instance, state_file=str(tmp_path / "state.json"), allow_shared_parameter_group=True)
+    capture.preflight()
+
+
+def test_preflight_rejects_insufficient_storage(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """A capture must not be able to fill the data volume."""
+    instance.free_storage_bytes = 21 * GIB
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight(max_log_size=5 * GIB, min_free_storage=20 * GIB)
+    assert "headroom" in str(exc_info.value)
+
+
+def test_preflight_rejects_unknown_storage(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """Unverifiable free space is treated as unsafe, not as fine."""
+    instance.free_storage_bytes = None
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        capture.preflight(min_free_storage=20 * GIB)
+    assert "cannot be verified" in str(exc_info.value)
+
+
+def test_preflight_propagates_parameter_errors(instance: MagicMock, capture: SlowLogCapture) -> None:
+    """A parameter missing from the engine family fails before anything changes."""
+    instance.parameter_group.validate_modifiable.side_effect = RDSParameterError("no such parameter")
+    with pytest.raises(RDSParameterError):
+        capture.preflight()
+
+
+def test_start_writes_state_file_before_applying(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """The state file must exist before the first parameter is touched."""
+    seen = {}
+
+    def record_apply(values):
+        seen["state_file_exists"] = osp.exists(capture.state_file)
+        seen["values"] = values
+
+    instance.parameter_group.apply.side_effect = record_apply
+    capture.start()
+
+    assert seen["state_file_exists"] is True
+    assert seen["values"] == capture.desired_parameters
+    with open(capture.state_file, encoding="utf8") as descriptor:
+        state = json.load(descriptor)
+    assert state["instance_id"] == "test-instance"
+    assert state["parameter_group"] == "test-pg"
+    assert [entry["name"] for entry in state["parameters"]] == CAPTURE_PARAMETERS
+
+
+def test_context_manager_restores_on_exception(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """Parameters go back even when the body blows up."""
+    with pytest.raises(ValueError):
+        with capture:
+            raise ValueError("boom")
+    instance.parameter_group.restore.assert_called_once()
+    assert not osp.exists(capture.state_file)
+
+
+def test_context_manager_restores_on_interrupt(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """Ctrl+C behaves like the shell script's INT trap."""
+    with pytest.raises(KeyboardInterrupt):
+        with capture:
+            raise KeyboardInterrupt
+    instance.parameter_group.restore.assert_called_once()
+
+
+def test_state_file_survives_failed_restore(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """If the restore fails the state file stays, so a human can finish the job."""
+    instance.parameter_group.restore.side_effect = SlowLogCaptureError("api is down")
+    capture.start()
+    with pytest.raises(SlowLogCaptureError):
+        capture.stop()
+    assert osp.exists(capture.state_file)
+
+
+def test_state_before_start_is_an_error(capture: SlowLogCapture) -> None:
+    """There is nothing to record before anything has been recorded."""
+    with pytest.raises(SlowLogCaptureError):
+        _ = capture.state
+
+
+def test_stop_without_start_is_a_noop(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """Restoring a capture that never started must not touch the parameter group."""
+    capture.stop()
+    instance.parameter_group.restore.assert_not_called()
+
+
+def test_captured_bytes_excludes_pre_existing_logs(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """Only growth counts — RDS log files predating the capture are not ours."""
+    instance.slow_log_files = [{"name": "slowquery/mysql-slowquery.log", "size": 500, "last_written": 1}]
+    capture.start()
+    instance.slow_log_files = [
+        {"name": "slowquery/mysql-slowquery.log", "size": 1500, "last_written": 2},
+        {"name": "slowquery/mysql-slowquery.log.2026-08-24.10", "size": 200, "last_written": 3},
+    ]
+    assert capture.captured_bytes == 1200
+
+
+def test_watch_stops_on_log_size(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """The size limit ends the capture."""
+    capture.start()
+    instance.slow_log_files = [{"name": "slowquery/mysql-slowquery.log", "size": 5000, "last_written": 1}]
+    reason = capture.watch(max_run_time=3600, max_log_size=1000, min_free_storage=GIB)
+    assert "log size limit" in reason
+
+
+def test_watch_stops_on_free_storage(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """The storage floor ends the capture before the volume fills."""
+    capture.start()
+    instance.free_storage_bytes = 5 * GIB
+    reason = capture.watch(max_run_time=3600, max_log_size=100 * GIB, min_free_storage=20 * GIB)
+    assert "free storage dropped" in reason
+
+
+def test_watch_stops_on_time(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """The time limit ends the capture."""
+    capture.start()
+    reason = capture.watch(max_run_time=0, max_log_size=100 * GIB, min_free_storage=GIB)
+    assert "time limit" in reason
+
+
+def test_watch_before_start_is_an_error(capture: SlowLogCapture) -> None:
+    """Watching a capture that never started is a programming error."""
+    with pytest.raises(SlowLogCaptureError):
+        capture.watch(max_run_time=1, max_log_size=1, min_free_storage=1)
+
+
+def test_download_skips_untouched_files(capture: SlowLogCapture, instance: MagicMock, tmp_path) -> None:
+    """Log files that did not grow during the window are not downloaded."""
+    instance.slow_log_files = [{"name": "slowquery/old.log", "size": 100, "last_written": 1}]
+    capture.start()
+    instance.slow_log_files = [
+        {"name": "slowquery/old.log", "size": 100, "last_written": 1},
+        {"name": "slowquery/new.log", "size": 42, "last_written": 2},
+    ]
+    instance.download_log_file.return_value = str(tmp_path / "new.log")
+
+    paths = capture.download(str(tmp_path / "out"))
+
+    assert len(paths) == 1
+    instance.download_log_file.assert_called_once_with("slowquery/new.log", str(tmp_path / "out"))
+
+
+def test_restore_from_state_file(tmp_path) -> None:
+    """A capture can be undone with nothing but its state file."""
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "instance_id": "test-instance",
+                "parameter_group": "test-pg",
+                "started_at": "2026-08-24T00:00:00+00:00",
+                "parameters": [{"name": "log_output", "value": "TABLE", "source": "system"}],
+            }
+        )
+    )
+    with patch("infrahouse_toolkit.aws.rds.slow_log_capture.RDSParameterGroup") as mock_group, patch(
+        "infrahouse_toolkit.aws.rds.slow_log_capture.RDSMySQLInstance"
+    ) as mock_instance:
+        assert SlowLogCapture.restore_from_state_file(str(state_file), MagicMock()) == "test-instance"
+
+    mock_group.return_value.restore.assert_called_once()
+    mock_instance.return_value.wait_parameters_in_sync.assert_called_once()
+    assert not state_file.exists()
+
+
+def test_restore_from_malformed_state_file(tmp_path) -> None:
+    """A truncated state file fails loudly instead of half-restoring."""
+    state_file = tmp_path / "state.json"
+    state_file.write_text('{"instance_id": "test-instance"}')
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        SlowLogCapture.restore_from_state_file(str(state_file), MagicMock())
+    assert "missing key" in str(exc_info.value)
+
+
+def test_restore_from_invalid_json(tmp_path) -> None:
+    """Garbage in the state file is reported as such."""
+    state_file = tmp_path / "state.json"
+    state_file.write_text("not json at all")
+    with pytest.raises(SlowLogCaptureError) as exc_info:
+        SlowLogCapture.restore_from_state_file(str(state_file), MagicMock())
+    assert "not valid JSON" in str(exc_info.value)
+
+
+def test_preflight_warns_about_dormant_cloudwatch_export(instance: MagicMock, capture: SlowLogCapture, caplog) -> None:
+    """Flipping log_output=FILE wakes a slowquery export that has been shipping nothing."""
+    instance.cloudwatch_log_exports = ["error", "general", "slowquery"]
+    instance.parameter_group.value_of.return_value = "TABLE"
+    capture.preflight()
+    assert "CloudWatch Logs ingestion is billable" in caplog.text
+
+
+def test_preflight_quiet_when_export_already_live(instance: MagicMock, capture: SlowLogCapture, caplog) -> None:
+    """Nothing changes for an instance already writing the log to a file."""
+    instance.cloudwatch_log_exports = ["error", "slowquery"]
+    instance.parameter_group.value_of.return_value = "FILE"
+    capture.preflight()
+    assert "billable" not in caplog.text
+
+
+def test_preflight_quiet_without_export(instance: MagicMock, capture: SlowLogCapture, caplog) -> None:
+    """No export configured, nothing to warn about."""
+    instance.cloudwatch_log_exports = ["error"]
+    instance.parameter_group.value_of.return_value = "TABLE"
+    capture.preflight()
+    assert "billable" not in caplog.text
+
+
+def test_start_rolls_back_when_apply_cannot_be_confirmed(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """__exit__ never runs if __enter__ raises, so start() must undo itself."""
+    instance.wait_parameters_in_sync.side_effect = [RDSError("timed out"), None]
+    with pytest.raises(RDSError):
+        capture.start()
+    instance.parameter_group.restore.assert_called_once()
+    assert not osp.exists(capture.state_file)
+
+
+def test_start_rollback_keeps_state_file_when_it_also_fails(capture: SlowLogCapture, instance: MagicMock) -> None:
+    """A failed rollback leaves the breadcrumb behind."""
+    instance.wait_parameters_in_sync.side_effect = RDSError("timed out")
+    instance.parameter_group.restore.side_effect = RDSError("api is down")
+    with pytest.raises(RDSError):
+        capture.start()
+    assert osp.exists(capture.state_file)

--- a/infrahouse_toolkit/cli/ih_mysql/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/__init__.py
@@ -15,6 +15,7 @@ from infrahouse_core.logging import setup_logging
 from infrahouse_toolkit.aws.config import AWSConfig
 from infrahouse_toolkit.cli.ih_mysql.cmd_bootstrap import cmd_bootstrap
 from infrahouse_toolkit.cli.ih_mysql.cmd_failover import cmd_failover
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit import cmd_query_audit
 
 LOG = getLogger(__name__)
 
@@ -61,7 +62,10 @@ def ih_mysql(ctx, **kwargs):
     }
 
 
-# noinspection PyTypeChecker
-ih_mysql.add_command(cmd_bootstrap)
-# noinspection PyTypeChecker
-ih_mysql.add_command(cmd_failover)
+for cmd in [
+    cmd_bootstrap,
+    cmd_failover,
+    cmd_query_audit,
+]:
+    # noinspection PyTypeChecker
+    ih_mysql.add_command(cmd)

--- a/infrahouse_toolkit/cli/ih_mysql/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/__init__.py
@@ -29,8 +29,8 @@ LOG = getLogger(__name__)
     show_default=True,
 )
 @click.option(
-    "--verbose",
-    help="Print INFO and WARNING level messages.",
+    "--quiet",
+    help="Suppress informational and warning messages, output errors only. Overrides --debug.",
     is_flag=True,
     default=False,
     show_default=True,
@@ -53,10 +53,15 @@ LOG = getLogger(__name__)
 @click.pass_context
 def ih_mysql(ctx, **kwargs):
     """MySQL/Percona Server management commands."""
-    setup_logging(debug=kwargs["debug"], quiet=not kwargs["verbose"])
+    # Three levels, with the useful one in the middle: --debug is everything,
+    # no flag prints INFO and WARNING, --quiet drops to errors only. Warnings
+    # here carry the safety findings, so suppressing them is opt-in.
+    quiet = kwargs["quiet"]
+    debug = kwargs["debug"] and not quiet
+    setup_logging(debug=debug, quiet=quiet)
 
     ctx.obj = {
-        "debug": kwargs["debug"],
+        "debug": debug,
         "aws_profile": kwargs["aws_profile"],
         "aws_region": kwargs["aws_region"],
     }

--- a/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/__init__.py
@@ -1,0 +1,49 @@
+"""
+.. topic:: ``ih-mysql query-audit``
+
+    Capture and digest the slow query log of an RDS for MySQL instance.
+
+    The workflow is::
+
+        ih-mysql query-audit status   <instance-id>   # what is configured now
+        ih-mysql query-audit capture  <instance-id>   # turn it up, wait, pull, restore
+        ih-mysql query-audit digest   <log-file>...   # re-slice an existing capture
+        ih-mysql query-audit restore  --state-file …  # undo a capture that died
+
+    See ``ih-mysql query-audit --help`` for more details.
+"""
+
+import sys
+from logging import getLogger
+
+import click
+from botocore.exceptions import NoRegionError
+from infrahouse_core.aws import get_aws_session
+from infrahouse_core.aws.config import AWSConfig
+
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.cmd_capture import cmd_capture
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.cmd_digest import cmd_digest
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.cmd_restore import cmd_restore
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.cmd_status import cmd_status
+
+LOG = getLogger(__name__)
+
+
+@click.group(name="query-audit")
+@click.pass_context
+def cmd_query_audit(ctx):
+    """Slow query log capture and analysis for RDS for MySQL."""
+    # Built here rather than in the ih-mysql group so that bootstrap and
+    # failover, which run from Puppet on instance boot, keep working without an
+    # STS round-trip on every invocation.
+    try:
+        ctx.obj["aws_session"] = get_aws_session(AWSConfig(), ctx.obj["aws_profile"], ctx.obj["aws_region"])
+    except NoRegionError as err:
+        LOG.error(err)
+        LOG.error("Use the --aws-region option to specify the AWS region.")
+        sys.exit(1)
+
+
+for command in [cmd_status, cmd_capture, cmd_digest, cmd_restore]:
+    # noinspection PyTypeChecker
+    cmd_query_audit.add_command(command)

--- a/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_capture/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_capture/__init__.py
@@ -58,18 +58,19 @@ DIGEST_REPORTS = [
 )
 @click.option(
     "--max-log-size",
-    help="Stop after the capture has written this many megabytes of slow log.",
+    help="Stop after the capture has written this many megabytes of slow log. Defaults to 1024, or 5% of "
+    "the instance's current allocated storage when that is smaller. 5% is a hard ceiling — a larger value "
+    "is refused, because a full-size capture must not push free storage under the reserve.",
     type=int,
-    default=1024,
-    show_default=True,
+    default=None,
 )
 @click.option(
     "--min-free-storage",
-    help="Stop if instance free storage drops to this many gigabytes. RDS keeps log files on the data "
-    "volume, so this is what stands between a capture and a storage-full outage.",
+    help="Stop if instance free storage drops to this many gigabytes. Defaults to 10% of the instance's "
+    "current allocated storage, which is the point where RDS starts autoextending the volume. Log files "
+    "live on the data volume, so this is what keeps a capture from provoking that.",
     type=int,
-    default=20,
-    show_default=True,
+    default=None,
 )
 @click.option(
     "--poll-interval",
@@ -86,7 +87,7 @@ DIGEST_REPORTS = [
 )
 @click.option(
     "--state-file",
-    help="Where to record pre-capture parameter values. Defaults to restore-state.json in the output " "directory.",
+    help="Where to record pre-capture parameter values. Defaults to restore-state.json in the output directory.",
     default=None,
 )
 @click.option(
@@ -146,10 +147,21 @@ def cmd_capture(ctx, **kwargs):  # pylint: disable=too-many-locals
     ``ih-mysql query-audit restore --state-file``.
 
     Omitting INSTANCE_ID lists the MySQL instances in the region.
+
+    \b
+    Known limitation: connections opened before the change keep their old
+    long_query_time, and this command cannot measure how many. It holds no
+    MySQL credentials, and performance_schema — the only place a session's
+    own threshold is visible — is off by default on RDS. So an empty capture
+    cannot be told apart from an idle instance from here. Compare the Queries
+    and Slow_queries counters in SHOW GLOBAL STATUS across the window to tell
+    which it was.
     """
     max_run_time = int(kwargs["max_run_time"] * 3600)
-    max_log_size = kwargs["max_log_size"] * 1024**2
-    min_free_storage = kwargs["min_free_storage"] * 1024**3
+    # Left as None so the capture can size them against the instance's own
+    # allocated storage; a flat default cannot suit both a 10 GiB and a 2 TiB volume.
+    max_log_size = None if kwargs["max_log_size"] is None else kwargs["max_log_size"] * 1024**2
+    min_free_storage = None if kwargs["min_free_storage"] is None else kwargs["min_free_storage"] * 1024**3
 
     try:
         session = ctx.obj["aws_session"]
@@ -170,6 +182,11 @@ def cmd_capture(ctx, **kwargs):  # pylint: disable=too-many-locals
         # Fail on a missing pt-query-digest now, not after an hour of capturing.
         if kwargs["digest"]:
             check_dependencies([PT_QUERY_DIGEST])
+
+        # Size the storage limits against this instance before they are used for
+        # the plan, the preflight and the watchdog alike.
+        max_log_size = capture.default_max_log_size if max_log_size is None else max_log_size
+        min_free_storage = capture.default_min_free_storage if min_free_storage is None else min_free_storage
 
         capture.preflight(max_log_size=max_log_size, min_free_storage=min_free_storage)
         _print_plan(capture, max_run_time, max_log_size, min_free_storage, output_dir)
@@ -196,16 +213,22 @@ def cmd_capture(ctx, **kwargs):  # pylint: disable=too-many-locals
                 reason = "interrupted"
         LOG.info("Capture finished: %s", reason)
 
-        log_files = capture.download(output_dir)
-        if not log_files:
-            LOG.error("Nothing was captured. Were the application's connections opened before the change?")
+        digest = QueryDigest(capture.download(output_dir), since=capture.started_at)
+        events = digest.event_count
+        if not events:
+            LOG.error(
+                "No queries were logged during the capture window. RDS writes a log file header even "
+                "when nothing is captured, so an empty capture still produces a file."
+            )
+            LOG.error(
+                "Connections opened before the change keep their old long_query_time. Give the client "
+                "pool time to recycle, or capture for longer."
+            )
             sys.exit(1)
+        LOG.info("Captured %d queries", events)
 
-        reports = []
-        if kwargs["digest"]:
-            reports = _run_digests(log_files, capture.started_at, output_dir)
-
-        _print_summary(output_dir, log_files, reports)
+        reports = _run_digests(digest, output_dir) if kwargs["digest"] else []
+        _print_summary(output_dir, digest.log_files, reports)
 
     except click.Abort:
         LOG.info("Aborted, nothing was changed")
@@ -246,14 +269,44 @@ def _print_plan(capture, max_run_time, max_log_size, min_free_storage, output_di
     rows = [
         [name, group.value_of(name), group.parameters[name].get("Source"), desired[name]] for name in CAPTURE_PARAMETERS
     ]
-    print(f"\nParameter group {group.name} on {capture.instance.db_instance_id}:\n")
+    gib = 1024**3
+    instance = capture.instance
+    allocated = instance.allocated_storage_bytes
+    free = instance.free_storage_bytes
+
+    print(f"\nParameter group {group.name} on {instance.db_instance_id}:\n")
     print(tabulate(rows, headers=["parameter", "current", "source", "capture sets"]))
     print(
+        f"\nStorage : {free / gib:.1f} GiB free of {allocated / gib:.0f} GiB allocated. "
+        f"Capture writes at most {max_log_size / gib:.1f} GiB, leaving "
+        f"{(free - max_log_size) / gib:.1f} GiB against a {min_free_storage / gib:.1f} GiB reserve."
+    )
+    print(
+        f"          The reserve is RDS's autoextend trigger — staying above it means the volume "
+        f"is never grown{_autoscaling_note(instance)}."
+    )
+    print(
         f"\nStops at: {max_run_time}s, or {max_log_size / 1024 ** 2:.0f} MiB of slow log, "
-        f"or {min_free_storage / 1024 ** 3:.0f} GiB free storage remaining."
+        f"or {min_free_storage / gib:.1f} GiB free storage remaining."
     )
     print(f"Output  : {output_dir}")
     print(f"Undo    : ih-mysql query-audit restore --state-file {capture.state_file}\n")
+
+
+def _autoscaling_note(instance) -> str:
+    """
+    Describe the autoextend ceiling the capture is staying clear of.
+
+    :param instance: The instance being captured on.
+    :type instance: RDSMySQLInstance
+    :return: A clause naming the threshold, or an empty string when storage
+        autoscaling is off.
+    :rtype: str
+    """
+    ceiling = instance.max_allocated_storage_bytes
+    if ceiling is None:
+        return " (autoscaling is off, so a full volume would be an outage)"
+    return f" (autoscaling is on, up to {ceiling / 1024 ** 3:.0f} GiB — deliberately unused)"
 
 
 def _print_summary(output_dir, log_files, reports) -> None:
@@ -275,21 +328,17 @@ def _print_summary(output_dir, log_files, reports) -> None:
         print(f"  {path}")
 
 
-def _run_digests(log_files, since, output_dir) -> list:
+def _run_digests(digest, output_dir) -> list:
     """
     Run the standard set of pt-query-digest reports over a capture.
 
-    :param log_files: Downloaded slow log files.
-    :type log_files: list
-    :param since: Capture start, used to exclude events that RDS had already
-        written to a log file before the capture began.
-    :type since: datetime
+    :param digest: The capture's log files, already scoped to the window.
+    :type digest: QueryDigest
     :param output_dir: Directory to write reports into.
     :type output_dir: str
     :return: Paths of the generated reports.
     :rtype: list
     """
-    digest = QueryDigest(log_files, since=since)
     paths = []
     for report in DIGEST_REPORTS:
         paths.append(

--- a/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_capture/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_capture/__init__.py
@@ -1,0 +1,302 @@
+"""
+.. topic:: ``ih-mysql query-audit capture``
+
+    Turn the slow query log all the way up on an RDS for MySQL instance for a
+    bounded window, download what it wrote, put every parameter back, and
+    digest the result.
+
+    See ``ih-mysql query-audit capture --help`` for more details.
+"""
+
+import sys
+from datetime import datetime, timezone
+from logging import getLogger
+from os import makedirs
+from os import path as osp
+
+import click
+from botocore.exceptions import ClientError
+from tabulate import tabulate
+
+from infrahouse_toolkit.aws.rds import (
+    CAPTURE_PARAMETERS,
+    QueryDigest,
+    QueryDigestError,
+    RDSError,
+    SlowLogCapture,
+)
+from infrahouse_toolkit.aws.rds.query_digest import PT_QUERY_DIGEST
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list import InstanceList
+from infrahouse_toolkit.cli.utils import check_dependencies
+
+LOG = getLogger(__name__)
+
+# The three cuts the profile needs: what costs the most time, what reads the
+# most rows, and how that splits per table.
+DIGEST_REPORTS = [
+    {"name": "digest-by-query-time.txt", "group_by": "fingerprint", "order_by": "Query_time:sum"},
+    {"name": "digest-by-rows-examined.txt", "group_by": "fingerprint", "order_by": "Rows_examined:sum"},
+    {"name": "digest-by-table.txt", "group_by": "tables", "order_by": "Query_time:sum"},
+]
+
+
+@click.command(name="capture")
+@click.option(
+    "--long-query-time",
+    help="Threshold to log at, in seconds. Zero logs everything, which is the point of an audit — "
+    "a nonzero threshold systematically hides the cheap, frequent queries.",
+    type=float,
+    default=0,
+    show_default=True,
+)
+@click.option(
+    "--max-run-time",
+    help="Stop after this many hours.",
+    type=float,
+    default=1.0,
+    show_default=True,
+)
+@click.option(
+    "--max-log-size",
+    help="Stop after the capture has written this many megabytes of slow log.",
+    type=int,
+    default=1024,
+    show_default=True,
+)
+@click.option(
+    "--min-free-storage",
+    help="Stop if instance free storage drops to this many gigabytes. RDS keeps log files on the data "
+    "volume, so this is what stands between a capture and a storage-full outage.",
+    type=int,
+    default=20,
+    show_default=True,
+)
+@click.option(
+    "--poll-interval",
+    help="Seconds between watchdog checks.",
+    type=int,
+    default=30,
+    show_default=True,
+)
+@click.option(
+    "--output-dir",
+    help="Directory for downloaded logs and reports. Defaults to a timestamped directory in the "
+    "current working directory.",
+    default=None,
+)
+@click.option(
+    "--state-file",
+    help="Where to record pre-capture parameter values. Defaults to restore-state.json in the output " "directory.",
+    default=None,
+)
+@click.option(
+    "--slow-extra/--no-slow-extra",
+    help="Record the extra per-query attributes (Rows_examined, Read_*, Tmp_tables).",
+    default=True,
+    show_default=True,
+)
+@click.option(
+    "--admin-statements/--no-admin-statements",
+    help="Log admin statements such as ALTER TABLE.",
+    default=True,
+    show_default=True,
+)
+@click.option(
+    "--allow-shared-parameter-group",
+    help="Proceed even when the parameter group is attached to more than one instance. This turns the "
+    "slow log up on every one of them.",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--digest/--no-digest",
+    help="Run pt-query-digest on the downloaded logs.",
+    default=True,
+    show_default=True,
+)
+@click.option(
+    "--dry-run",
+    help="Run the preflight checks and print the plan without changing anything.",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--yes",
+    "-y",
+    help="Do not ask for confirmation.",
+    is_flag=True,
+    default=False,
+)
+@click.argument("instance_id", required=False)
+@click.pass_context
+def cmd_capture(ctx, **kwargs):  # pylint: disable=too-many-locals
+    """
+    Capture and digest the slow query log of a DB instance.
+
+    \b
+    The capture:
+      1. records every parameter it is about to change, to a state file;
+      2. sets log_output=FILE, slow_query_log=1, long_query_time and friends;
+      3. watches time, log size and free storage until a limit is hit;
+      4. restores every parameter to exactly what it found;
+      5. downloads what was written and runs pt-query-digest over it.
+
+    Parameters are restored on interrupt and on error too. If restoring itself
+    fails, the state file is left behind — undo it with
+    ``ih-mysql query-audit restore --state-file``.
+
+    Omitting INSTANCE_ID lists the MySQL instances in the region.
+    """
+    max_run_time = int(kwargs["max_run_time"] * 3600)
+    max_log_size = kwargs["max_log_size"] * 1024**2
+    min_free_storage = kwargs["min_free_storage"] * 1024**3
+
+    try:
+        session = ctx.obj["aws_session"]
+        instance = InstanceList(session, region=ctx.obj["aws_region"]).require(kwargs["instance_id"])
+        instance_id = instance.db_instance_id
+        output_dir = kwargs["output_dir"] or _default_output_dir(instance_id)
+        state_file = kwargs["state_file"] or osp.join(output_dir, "restore-state.json")
+        makedirs(output_dir, exist_ok=True)
+        capture = SlowLogCapture(
+            instance,
+            long_query_time=kwargs["long_query_time"],
+            log_slow_extra=kwargs["slow_extra"],
+            log_slow_admin_statements=kwargs["admin_statements"],
+            state_file=state_file,
+            allow_shared_parameter_group=kwargs["allow_shared_parameter_group"],
+        )
+
+        # Fail on a missing pt-query-digest now, not after an hour of capturing.
+        if kwargs["digest"]:
+            check_dependencies([PT_QUERY_DIGEST])
+
+        capture.preflight(max_log_size=max_log_size, min_free_storage=min_free_storage)
+        _print_plan(capture, max_run_time, max_log_size, min_free_storage, output_dir)
+
+        if kwargs["dry_run"]:
+            LOG.info("Dry run: nothing was changed")
+            sys.exit(0)
+
+        if not kwargs["yes"]:
+            click.confirm(
+                f"Turn the slow query log up on {instance_id} for up to {kwargs['max_run_time']}h?",
+                abort=True,
+            )
+
+        with capture:
+            try:
+                reason = capture.watch(
+                    max_run_time=max_run_time,
+                    max_log_size=max_log_size,
+                    min_free_storage=min_free_storage,
+                    poll_interval=kwargs["poll_interval"],
+                )
+            except KeyboardInterrupt:
+                reason = "interrupted"
+        LOG.info("Capture finished: %s", reason)
+
+        log_files = capture.download(output_dir)
+        if not log_files:
+            LOG.error("Nothing was captured. Were the application's connections opened before the change?")
+            sys.exit(1)
+
+        reports = []
+        if kwargs["digest"]:
+            reports = _run_digests(log_files, capture.started_at, output_dir)
+
+        _print_summary(output_dir, log_files, reports)
+
+    except click.Abort:
+        LOG.info("Aborted, nothing was changed")
+        sys.exit(1)
+    except (RDSError, QueryDigestError, ClientError) as err:
+        LOG.error("%s", err)
+        sys.exit(1)
+
+
+def _default_output_dir(instance_id: str) -> str:
+    """
+    :param instance_id: DB instance identifier.
+    :type instance_id: str
+    :return: A timestamped directory name for this capture.
+    :rtype: str
+    """
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+    return f"query-audit-{instance_id}-{stamp}"
+
+
+def _print_plan(capture, max_run_time, max_log_size, min_free_storage, output_dir) -> None:
+    """
+    Print what the capture will change and what will stop it.
+
+    :param capture: The configured capture.
+    :type capture: SlowLogCapture
+    :param max_run_time: Time limit in seconds.
+    :type max_run_time: int
+    :param max_log_size: Log size limit in bytes.
+    :type max_log_size: int
+    :param min_free_storage: Free storage floor in bytes.
+    :type min_free_storage: int
+    :param output_dir: Directory results are written to.
+    :type output_dir: str
+    """
+    group = capture.instance.parameter_group
+    desired = capture.desired_parameters
+    rows = [
+        [name, group.value_of(name), group.parameters[name].get("Source"), desired[name]] for name in CAPTURE_PARAMETERS
+    ]
+    print(f"\nParameter group {group.name} on {capture.instance.db_instance_id}:\n")
+    print(tabulate(rows, headers=["parameter", "current", "source", "capture sets"]))
+    print(
+        f"\nStops at: {max_run_time}s, or {max_log_size / 1024 ** 2:.0f} MiB of slow log, "
+        f"or {min_free_storage / 1024 ** 3:.0f} GiB free storage remaining."
+    )
+    print(f"Output  : {output_dir}")
+    print(f"Undo    : ih-mysql query-audit restore --state-file {capture.state_file}\n")
+
+
+def _print_summary(output_dir, log_files, reports) -> None:
+    """
+    Print where everything landed.
+
+    :param output_dir: Directory results were written to.
+    :type output_dir: str
+    :param log_files: Downloaded slow log files.
+    :type log_files: list
+    :param reports: Generated digest reports.
+    :type reports: list
+    """
+    total = sum(osp.getsize(path) for path in log_files)
+    print(f"\nCaptured {total / 1024 ** 2:.1f} MiB across {len(log_files)} log file(s) in {output_dir}:")
+    for path in log_files:
+        print(f"  {path}")
+    for path in reports:
+        print(f"  {path}")
+
+
+def _run_digests(log_files, since, output_dir) -> list:
+    """
+    Run the standard set of pt-query-digest reports over a capture.
+
+    :param log_files: Downloaded slow log files.
+    :type log_files: list
+    :param since: Capture start, used to exclude events that RDS had already
+        written to a log file before the capture began.
+    :type since: datetime
+    :param output_dir: Directory to write reports into.
+    :type output_dir: str
+    :return: Paths of the generated reports.
+    :rtype: list
+    """
+    digest = QueryDigest(log_files, since=since)
+    paths = []
+    for report in DIGEST_REPORTS:
+        paths.append(
+            digest.report(
+                osp.join(output_dir, report["name"]),
+                group_by=report["group_by"],
+                order_by=report["order_by"],
+            )
+        )
+    return paths

--- a/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_digest/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_digest/__init__.py
@@ -1,0 +1,78 @@
+"""
+.. topic:: ``ih-mysql query-audit digest``
+
+    Run ``pt-query-digest`` over slow log files that have already been
+    downloaded.
+
+    Useful for re-slicing a capture without repeating it — by table, by rows
+    examined, or filtered down to the queries that touch one table.
+
+    See ``ih-mysql query-audit digest --help`` for more details.
+"""
+
+import sys
+from logging import getLogger
+
+import click
+
+from infrahouse_toolkit.aws.rds import QueryDigest, QueryDigestError
+from infrahouse_toolkit.aws.rds.query_digest import PT_QUERY_DIGEST
+from infrahouse_toolkit.cli.utils import check_dependencies
+
+LOG = getLogger(__name__)
+
+
+@click.command(name="digest")
+@click.option(
+    "--group-by",
+    help="What to aggregate on. ``fingerprint`` ranks individual queries, ``tables`` gives the " "per-table breakdown.",
+    default="fingerprint",
+    show_default=True,
+)
+@click.option(
+    "--order-by",
+    help="Ranking attribute, e.g. Query_time:sum or Rows_examined:sum.",
+    default="Query_time:sum",
+    show_default=True,
+)
+@click.option(
+    "--limit",
+    help="How many query classes to report, in pt-query-digest syntax.",
+    default="20",
+    show_default=True,
+)
+@click.option(
+    "--filter",
+    "query_filter",
+    help="Perl expression for pt-query-digest --filter, "
+    "e.g. '$event->{arg} =~ m/fetch_results/' to keep only queries touching one table.",
+    default=None,
+)
+@click.option(
+    "--output",
+    help="Write the report here instead of standard output.",
+    default=None,
+)
+@click.argument("log_files", nargs=-1, required=True, type=click.Path(exists=True, dir_okay=False))
+@click.pass_context
+def cmd_digest(ctx, group_by, order_by, limit, query_filter, output, log_files):  # pylint: disable=too-many-arguments
+    """
+    Digest already-downloaded slow log files.
+
+    LOG_FILES are slow log files as downloaded by ``query-audit capture``.
+    """
+    del ctx  # No AWS access needed; this runs entirely on local files.
+    check_dependencies([PT_QUERY_DIGEST])
+    try:
+        digest = QueryDigest(list(log_files))
+        destination = output or "/dev/stdout"
+        digest.report(
+            destination,
+            group_by=group_by,
+            order_by=order_by,
+            limit=limit,
+            query_filter=query_filter,
+        )
+    except QueryDigestError as err:
+        LOG.error("%s", err)
+        sys.exit(1)

--- a/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_restore/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_restore/__init__.py
@@ -1,0 +1,48 @@
+"""
+.. topic:: ``ih-mysql query-audit restore``
+
+    Undo a slow query log capture from its state file.
+
+    ``capture`` restores parameters on its own way out, including on interrupt.
+    This command is for when it could not: the process was killed outright, the
+    laptop closed, or the restore API call itself failed. An instance left at
+    ``long_query_time=0`` keeps filling its volume, so this is the emergency
+    brake.
+
+    See ``ih-mysql query-audit restore --help`` for more details.
+"""
+
+import sys
+from logging import getLogger
+
+import click
+from botocore.exceptions import ClientError
+
+from infrahouse_toolkit.aws.rds import RDSError, SlowLogCapture
+
+LOG = getLogger(__name__)
+
+
+@click.command(name="restore")
+@click.option(
+    "--state-file",
+    help="State file written by ``ih-mysql query-audit capture``.",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+)
+@click.pass_context
+def cmd_restore(ctx, state_file):
+    """
+    Restore DB parameters recorded in a capture state file.
+
+    Parameters that were explicitly set before the capture are set back to
+    their old values; parameters that were merely inheriting a default are
+    reset rather than pinned to it. The state file is removed on success.
+    """
+    try:
+        instance_id = SlowLogCapture.restore_from_state_file(state_file, ctx.obj["aws_session"])
+        LOG.info("Restored %s and removed %s", instance_id, state_file)
+    except (RDSError, ClientError, OSError) as err:
+        LOG.error("%s", err)
+        LOG.error("The state file was left in place: %s", state_file)
+        sys.exit(1)

--- a/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_status/__init__.py
+++ b/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/cmd_status/__init__.py
@@ -1,0 +1,123 @@
+"""
+.. topic:: ``ih-mysql query-audit status``
+
+    Report what an RDS for MySQL instance is currently logging, and what a
+    capture would have to change.
+
+    See ``ih-mysql query-audit status --help`` for more details.
+"""
+
+import sys
+from logging import getLogger
+
+import click
+from botocore.exceptions import ClientError
+from tabulate import tabulate
+
+from infrahouse_toolkit.aws.rds import CAPTURE_PARAMETERS, RDSError, SlowLogCapture
+from infrahouse_toolkit.cli.ih_mysql.cmd_query_audit.instance_list import InstanceList
+
+LOG = getLogger(__name__)
+
+
+@click.command(name="status")
+@click.argument("instance_id", required=False)
+@click.pass_context
+def cmd_status(ctx, instance_id):
+    """
+    Show the slow query log configuration of a DB instance.
+
+    Read-only.  Run this before a capture to see what will change and whether
+    anything stands in the way.
+
+    Omitting INSTANCE_ID lists the MySQL instances in the region.
+    """
+    try:
+        session = ctx.obj["aws_session"]
+        instance = InstanceList(session, region=ctx.obj["aws_region"]).require(instance_id)
+        group = instance.parameter_group
+        capture = SlowLogCapture(instance)
+        desired = capture.desired_parameters
+
+        print(f"Instance          : {instance.db_instance_id}")
+        print(f"Engine            : {instance.engine} {instance.engine_version}")
+        print(f"Status            : {instance.status}")
+        print(f"Parameter group   : {group.name} ({group.family})")
+        print(f"Attached to       : {', '.join(group.attached_instance_ids)}")
+        print(f"CloudWatch exports: {', '.join(instance.cloudwatch_log_exports) or 'none'}")
+        print(f"Perf. Insights    : {'enabled' if instance.performance_insights_enabled else 'disabled'}")
+        free = instance.free_storage_bytes
+        print(f"Free storage      : {f'{free / 1024 ** 3:.1f} GiB' if free is not None else 'unknown'}")
+        print()
+
+        rows = []
+        for name in CAPTURE_PARAMETERS + ["performance_schema", "slow_query_log_file"]:
+            parameter = group.parameters.get(name)
+            if parameter is None:
+                rows.append([name, "<not in family>", "-", "-", "-"])
+                continue
+            rows.append(
+                [
+                    name,
+                    parameter.get("ParameterValue"),
+                    parameter.get("Source"),
+                    parameter.get("ApplyType"),
+                    desired.get(name, "-"),
+                ]
+            )
+        print(tabulate(rows, headers=["parameter", "value", "source", "apply", "capture would set"]))
+        print()
+
+        _warn_about_findings(instance, group)
+
+    except (RDSError, ClientError) as err:
+        LOG.error("%s", err)
+        sys.exit(1)
+
+
+def _warn_about_findings(instance, group) -> None:
+    """
+    Point out the configurations that quietly break a slow query log audit.
+
+    :param instance: The instance being reported on.
+    :type instance: RDSMySQLInstance
+    :param group: Its parameter group.
+    :type group: RDSParameterGroup
+    """
+    if group.value_of("log_output") != "FILE":
+        LOG.warning(
+            "log_output is %s: the slow log goes to the mysql.slow_log table, no log file is produced, "
+            "log_slow_extra has no effect, and any CloudWatch slowquery export stays silent.",
+            group.value_of("log_output"),
+        )
+        if "slowquery" in instance.cloudwatch_log_exports:
+            LOG.warning(
+                "slowquery is in EnabledCloudwatchLogsExports but nothing can be published while "
+                "log_output is not FILE."
+            )
+
+    long_query_time = group.value_of("long_query_time")
+    if long_query_time is None:
+        LOG.warning(
+            "long_query_time is unset, so the engine default of 10s applies — far too high to see the "
+            "cheap, frequent queries an access-pattern audit is about."
+        )
+
+    if group.value_of("performance_schema") in ("0", None):
+        LOG.warning(
+            "performance_schema is off, so events_statements_summary_by_digest is empty and the slow log "
+            "is the only source. Turning it on requires a reboot."
+        )
+
+    if group.is_default:
+        LOG.warning("%s is a default parameter group and cannot be modified.", group.name)
+
+    attached = group.attached_instance_ids
+    if len(attached) > 1:
+        LOG.warning(
+            "Parameter group %s is shared by %d instances (%s). A capture would turn the slow log up "
+            "on all of them.",
+            group.name,
+            len(attached),
+            ", ".join(attached),
+        )

--- a/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/instance_list.py
+++ b/infrahouse_toolkit/cli/ih_mysql/cmd_query_audit/instance_list.py
@@ -1,0 +1,92 @@
+"""
+DB instance listing for the ``query-audit`` commands.
+
+Lets ``status`` and ``capture`` answer a missing ``INSTANCE_ID`` with the
+choices instead of a bare usage error.  The table matches the format
+``ih-ec2 list`` uses for EC2 instances.
+"""
+
+from logging import getLogger
+from typing import List, Optional
+
+import click
+from tabulate import tabulate
+
+from infrahouse_toolkit.aws.rds import RDSMySQLInstance
+
+LOG = getLogger(__name__)
+
+
+class InstanceList:
+    """
+    The RDS for MySQL instances in a region.
+
+    :param session: Authenticated boto3 session.
+    :type session: Session
+    :param region: AWS region.
+    :type region: str
+    """
+
+    def __init__(self, session, region: str = None) -> None:
+        self._session = session
+        self._region = region
+        self._instances: Optional[List[RDSMySQLInstance]] = None
+
+    # --- Public properties ---
+
+    @property
+    def instances(self) -> List[RDSMySQLInstance]:
+        """
+        :return: MySQL DB instances in the region, ordered by identifier.
+        :rtype: List[RDSMySQLInstance]
+        """
+        if self._instances is None:
+            self._instances = RDSMySQLInstance.list_instances(session=self._session, region=self._region)
+        return self._instances
+
+    @property
+    def table(self) -> str:
+        """
+        The instances, formatted the way ``ih-ec2 list`` formats EC2 instances.
+
+        :return: A rendered table.
+        :rtype: str
+        """
+        rows = [
+            [
+                instance.tags.get("Name") or instance.tags.get("service"),
+                instance.db_instance_id,
+                f"{instance.engine} {instance.engine_version}",
+                instance.description["DBInstanceClass"],
+                instance.status,
+            ]
+            for instance in self.instances
+        ]
+        return tabulate(
+            rows,
+            headers=["Name", "DBInstanceIdentifier", "Engine", "DBInstanceClass", "State"],
+            tablefmt="outline",
+        )
+
+    # --- Public methods ---
+
+    def require(self, instance_id: str) -> RDSMySQLInstance:
+        """
+        Resolve *instance_id*, or fail with the list of valid identifiers.
+
+        :param instance_id: DB instance identifier, or ``None`` when the
+            argument was omitted.
+        :type instance_id: str
+        :return: The named instance.
+        :rtype: RDSMySQLInstance
+        :raises click.UsageError: If *instance_id* is missing.
+        """
+        if instance_id:
+            return RDSMySQLInstance(instance_id, region=self._region, session=self._session)
+
+        if not self.instances:
+            raise click.UsageError(
+                "Missing argument 'INSTANCE_ID', and no RDS for MySQL instances were found. "
+                "Check --aws-profile and --aws-region."
+            )
+        raise click.UsageError(f"Missing argument 'INSTANCE_ID'. Pick one of:\n\n{self.table}")


### PR DESCRIPTION
Ports a long-standing "collect a slow log for a while, then digest it" shell script to RDS for MySQL, where two of its mechanisms are unavailable.

There is no `SET GLOBAL` and `slow_query_log_file` is not modifiable, so every change goes through the DB parameter group. And `log_output` defaults to `TABLE`, which writes to `mysql.slow_log` instead of a file: pt-query-digest cannot read that, `log_slow_extra` has no effect there, and a configured CloudWatch `slowquery` export publishes nothing. The capture flips it to `FILE` and restores it afterwards.

## Commands

| Command | Purpose |
|---------|---------|
| `ih-mysql query-audit status` | read-only report of what is configured |
| `ih-mysql query-audit capture` | turn it up, watch, pull, restore, digest |
| `ih-mysql query-audit digest` | re-slice an existing capture |
| `ih-mysql query-audit restore` | undo a capture that died mid-flight |

Omitting the instance identifier lists the MySQL instances in the region, in the same table format `ih-ec2 list` uses.

## Safety, in place of the shell script's traps

* the pre-capture parameter values are written to a state file *before* anything is modified, and `restore` distinguishes user-set values from inherited defaults so a reset is not turned into a pin;
* parameters are restored on success, on error, on Ctrl+C and on SIGTERM; `start()` rolls itself back too, since `__exit__` never runs if `__enter__` raises;
* the watchdog stops on elapsed time, on bytes written, and on instance free storage, because RDS keeps log files on the data volume;
* preflight refuses a default parameter group, a group shared by several instances, free space it cannot verify, and a missing pt-query-digest.

Percona's `log_slow_verbosity` and `use_global_long_query_time` have no community MySQL equivalent. `log_slow_extra` replaces the first; nothing replaces the second, so the capture warns that pooled connections keep their old `long_query_time` until the pool recycles.

Reuses infrahouse-core: `RDSMySQLInstance` extends its `RDSInstance` and `RDSParameterGroup` extends `AWSResource`, so both inherit the exists/delete contract and the lazy, region- and role-aware client. Core has no parameter group, DB log file or CloudWatch metric wrapper today; those are added here and should migrate upstream (infrahouse/infrahouse-core#150).

## Fixes from exercising the capture against live MySQL 8.0 and 8.4

Version zero produced a usable query profile; these are the defects that surfaced getting there.

**The capture window was consumed by its own setup.** `started_at` was stamped before the parameter group was applied, but RDS takes about a minute to report a dynamic change in-sync, and nothing is logged until it does. A short capture spent its entire budget on that latency and recorded only what leaked in during the restore. The clock now starts once the group is in-sync, and the same timestamp is what `pt-query-digest --since` receives, so the digest window matches the capture window.

**Storage limits are now proportional to the volume.** A flat 20 GiB reserve is unsatisfiable on a 10 GiB instance — larger than the whole volume — and far too thin on 2 TiB. The reserve is 10% of current allocated storage, which is RDS's own storage-autoscaling trigger: staying above it means the volume is never grown. Separately, 5% of allocated is a safety ceiling, not a working size: it made the default 100 GiB of slow log on a 2 TiB volume. The default is now 1 GiB, or the ceiling where that is smaller.

**An empty capture was reported as a success.** RDS writes a log file header when it creates the slow log, so a capture that recorded nothing still produced a non-empty file and passed both a file-count and a byte-count check. Coverage is now decided by counting logged query events.

**Log levels follow the `--debug` / no flag / `--quiet` convention** that ih-certbot, ih-elastic and ih-puppet already use. Previously ih-mysql defaulted to quiet, which routes both handlers to ERROR — so every warning this feature emits, including the parameter restore confirmation and the whole of `query-audit status`'s findings, was discarded.

## Breaking change

`ih-mysql --verbose` is gone; callers passing it will now fail. Use the default level or `--debug`.

## Known limitation

Documented rather than fixed: the capture cannot measure how much of the workload it actually saw. `long_query_time` is seeded per session at connect time and community MySQL has no equivalent of Percona's `use_global_long_query_time`, so pooled clients contribute nothing until they recycle. This tool holds no MySQL credentials and `performance_schema` is off by default on RDS, so an idle instance and a stale connection pool are indistinguishable from the control plane.

## Test plan

* `pytest infrahouse_toolkit/aws/tests/rds` — 104 tests, all passing.
* Exercised end to end against live RDS MySQL 8.0 and 8.4 instances: capture, digest, status, and restore after an interrupted capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gi8o3APMXc8sS8go9qhMT
